### PR TITLE
fix: auto-tagワークフローのバージョンファイルパスをルートに変更

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Read version
         id: version
         run: |
-          VERSION=$(cat docs/aidlc/version.txt | tr -d '\n\r ')
+          VERSION=$(cat version.txt | tr -d '\n\r ')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary
- auto-tagワークフローが参照するバージョンファイルを `docs/aidlc/version.txt` から `version.txt`（ルート）に変更

## Test plan
- [ ] mainへのマージ時にauto-tagワークフローが正しくルートのversion.txtを参照することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)