### PR TITLE
fix: squash-unit.sh retroactiveモードの単一コミットUnit処理バグ修正

### DIFF
--- a/docs/aidlc/bin/squash-unit.sh
+++ b/docs/aidlc/bin/squash-unit.sh
@@ -351,6 +351,10 @@ find_unit_commit_range_git() {
                     last_short="$short_hash"
                     last_full="$full_hash"
                     hashes="$short_hash"
+                    # 単一コミットUnit: 最初のコミットが完了コミットなら即終了
+                    if [[ "$subject" == "${target_unit_pattern}"* ]]; then
+                        break
+                    fi
                 fi
             else
                 # Unit 002+: 前Unitの完了コミットの次から開始
@@ -365,6 +369,10 @@ find_unit_commit_range_git() {
                     last_short="$short_hash"
                     last_full="$full_hash"
                     hashes="$short_hash"
+                    # 単一コミットUnit: 最初のコミットが完了コミットなら即終了
+                    if [[ "$subject" == "${target_unit_pattern}"* ]]; then
+                        break
+                    fi
                 fi
             fi
         else

--- a/prompts/package/bin/squash-unit.sh
+++ b/prompts/package/bin/squash-unit.sh
@@ -351,6 +351,10 @@ find_unit_commit_range_git() {
                     last_short="$short_hash"
                     last_full="$full_hash"
                     hashes="$short_hash"
+                    # 単一コミットUnit: 最初のコミットが完了コミットなら即終了
+                    if [[ "$subject" == "${target_unit_pattern}"* ]]; then
+                        break
+                    fi
                 fi
             else
                 # Unit 002+: 前Unitの完了コミットの次から開始
@@ -365,6 +369,10 @@ find_unit_commit_range_git() {
                     last_short="$short_hash"
                     last_full="$full_hash"
                     hashes="$short_hash"
+                    # 単一コミットUnit: 最初のコミットが完了コミットなら即終了
+                    if [[ "$subject" == "${target_unit_pattern}"* ]]; then
+                        break
+                    fi
                 fi
             fi
         else


### PR DESCRIPTION
## Summary
- `--retroactive`モードで単一コミットのUnitを処理する際、`found_start`後の最初のコミットが`target_unit_pattern`に一致するかチェックしていなかったため、次Unitのコミットまで収集し続けるバグを修正

## Test plan
- [ ] 単一コミットUnitに対して`--retroactive --dry-run`を実行し、対象コミットが1件のみであることを確認
- [ ] 複数コミットUnitに対する既存動作が変わらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)