### PR TITLE
fix: merge-prの空配列引数エラーを修正

### DIFF
--- a/skills/aidlc/scripts/operations-release.sh
+++ b/skills/aidlc/scripts/operations-release.sh
@@ -622,6 +622,8 @@ cmd_merge_pr() {
         return 1
     fi
 
+    # Bash 3.2 + set -u では空配列の "${array[@]}" が unbound variable になるため、
+    # 追加引数がある場合だけ配列展開する。
     local -a extra_args=()
     if [[ "$skip_checks" -eq 1 ]]; then
         extra_args+=("--skip-checks")
@@ -633,7 +635,11 @@ cmd_merge_pr() {
                 log_dry_run "$SCRIPT_DIR/pr-ops.sh merge $pr_number${extra_args[*]:+ ${extra_args[*]}}"
                 return 0
             fi
-            "$SCRIPT_DIR/pr-ops.sh" merge "$pr_number" "${extra_args[@]}"
+            if [[ ${#extra_args[@]} -gt 0 ]]; then
+                "$SCRIPT_DIR/pr-ops.sh" merge "$pr_number" "${extra_args[@]}"
+            else
+                "$SCRIPT_DIR/pr-ops.sh" merge "$pr_number"
+            fi
             return $?
             ;;
         squash)
@@ -641,7 +647,11 @@ cmd_merge_pr() {
                 log_dry_run "$SCRIPT_DIR/pr-ops.sh merge $pr_number --squash${extra_args[*]:+ ${extra_args[*]}}"
                 return 0
             fi
-            "$SCRIPT_DIR/pr-ops.sh" merge "$pr_number" --squash "${extra_args[@]}"
+            if [[ ${#extra_args[@]} -gt 0 ]]; then
+                "$SCRIPT_DIR/pr-ops.sh" merge "$pr_number" --squash "${extra_args[@]}"
+            else
+                "$SCRIPT_DIR/pr-ops.sh" merge "$pr_number" --squash
+            fi
             return $?
             ;;
         rebase)
@@ -649,7 +659,11 @@ cmd_merge_pr() {
                 log_dry_run "$SCRIPT_DIR/pr-ops.sh merge $pr_number --rebase${extra_args[*]:+ ${extra_args[*]}}"
                 return 0
             fi
-            "$SCRIPT_DIR/pr-ops.sh" merge "$pr_number" --rebase "${extra_args[@]}"
+            if [[ ${#extra_args[@]} -gt 0 ]]; then
+                "$SCRIPT_DIR/pr-ops.sh" merge "$pr_number" --rebase "${extra_args[@]}"
+            else
+                "$SCRIPT_DIR/pr-ops.sh" merge "$pr_number" --rebase
+            fi
             return $?
             ;;
         *)

--- a/skills/aidlc/scripts/tests/test_operations_release_merge_pr_empty_args.sh
+++ b/skills/aidlc/scripts/tests/test_operations_release_merge_pr_empty_args.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# test_operations_release_merge_pr_empty_args.sh - operations-release.sh merge-pr の
+# 追加引数なし呼び出し regression テスト。
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OPERATIONS_RELEASE="${SCRIPT_DIR}/../operations-release.sh"
+TMPDIR_BASE=""
+COUNTER_FILE=""
+
+# --- テストヘルパー ---
+
+setup_tmpdir() {
+    TMPDIR_BASE=$(mktemp -d)
+    COUNTER_FILE="${TMPDIR_BASE}/.test_counters"
+    printf '0\n0\n' > "$COUNTER_FILE"
+    cp "$OPERATIONS_RELEASE" "${TMPDIR_BASE}/operations-release.sh"
+    chmod +x "${TMPDIR_BASE}/operations-release.sh"
+
+    cat > "${TMPDIR_BASE}/pr-ops.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'argc:%d\n' "$#"
+i=1
+for arg in "$@"; do
+    printf 'arg%d:%s\n' "$i" "$arg"
+    i=$(( i + 1 ))
+done
+STUB
+    chmod +x "${TMPDIR_BASE}/pr-ops.sh"
+}
+
+cleanup_tmpdir() {
+    if [ -n "$TMPDIR_BASE" ] && [ -d "$TMPDIR_BASE" ]; then
+        \rm -rf "$TMPDIR_BASE"
+    fi
+}
+trap cleanup_tmpdir EXIT
+
+_inc_pass() {
+    local pass fail
+    { read -r pass; read -r fail; } < "$COUNTER_FILE"
+    printf '%d\n%d\n' "$(( pass + 1 ))" "$fail" > "$COUNTER_FILE"
+}
+
+_inc_fail() {
+    local pass fail
+    { read -r pass; read -r fail; } < "$COUNTER_FILE"
+    printf '%d\n%d\n' "$pass" "$(( fail + 1 ))" > "$COUNTER_FILE"
+}
+
+assert_eq() {
+    local test_name="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "  PASS: $test_name"
+        _inc_pass
+    else
+        echo "  FAIL: $test_name"
+        echo "    expected: $expected"
+        echo "    actual:   $actual"
+        _inc_fail
+    fi
+}
+
+run_merge_pr() {
+    "${TMPDIR_BASE}/operations-release.sh" merge-pr "$@" 2>&1
+}
+
+# --- テスト本体 ---
+
+echo "=== operations-release.sh merge-pr 追加引数なしテスト ==="
+
+setup_tmpdir
+
+echo ""
+echo "[Case 1] squash + 追加引数なし"
+actual=$(run_merge_pr --pr 123 --method squash)
+expected="argc:3
+arg1:merge
+arg2:123
+arg3:--squash"
+assert_eq "squash: pr-ops 引数" "$expected" "$actual"
+
+echo ""
+echo "[Case 2] merge + 追加引数なし"
+actual=$(run_merge_pr --pr 123 --method merge)
+expected="argc:2
+arg1:merge
+arg2:123"
+assert_eq "merge: pr-ops 引数" "$expected" "$actual"
+
+echo ""
+echo "[Case 3] rebase + 追加引数なし"
+actual=$(run_merge_pr --pr 123 --method rebase)
+expected="argc:3
+arg1:merge
+arg2:123
+arg3:--rebase"
+assert_eq "rebase: pr-ops 引数" "$expected" "$actual"
+
+echo ""
+echo "[Case 4] squash + --skip-checks"
+actual=$(run_merge_pr --pr 123 --method squash --skip-checks)
+expected="argc:4
+arg1:merge
+arg2:123
+arg3:--squash
+arg4:--skip-checks"
+assert_eq "squash+skip: pr-ops 引数" "$expected" "$actual"
+
+# --- 結果集計 ---
+
+echo ""
+{ read -r pass_count; read -r fail_count; } < "$COUNTER_FILE"
+total=$(( pass_count + fail_count ))
+echo "=== 結果: PASS=$pass_count / FAIL=$fail_count / TOTAL=$total ==="
+
+if [ "$fail_count" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要
- operations-release.sh merge-pr で追加引数なしの場合に Bash 3.2 + set -u で失敗する問題を修正
- extra_args がある場合だけ配列展開し、空の場合は追加引数なしで pr-ops.sh を呼び出すように変更
- merge / squash / rebase の追加引数なしケースと --skip-checks ありケースの regression テストを追加

## 確認
- bash skills/aidlc/scripts/tests/test_operations_release_merge_pr_empty_args.sh
- bash skills/aidlc/scripts/tests/test_pr_ops_merge_skip_checks.sh
- bash bin/check-bash-substitution.sh
- git diff --check

Closes #589