### PR TITLE
[Release] v3.0.0-alpha.9

### DIFF
--- a/.aidlc/cycles/v3.0.0-alpha.9/designs/001-doctor-trace-downstream.md
+++ b/.aidlc/cycles/v3.0.0-alpha.9/designs/001-doctor-trace-downstream.md
@@ -22,7 +22,7 @@
 
 1. **Traceability 健全性検証**（work item 単位 / ループ内）:
    - `body="$(fm_extract_body "$f")"` で本文を取得。
-   - ヘルパー `_trace_traceability_healthy <body>`: `## Traceability` セクション内の `Intent refs:` / `Acceptance refs:` / `Verification:` の 3 フィールドが、いずれも「空白除去後に非空」かつ「`{{` プレースホルダを含まない」なら健全（return 0）。1 つでも欠ければ不備（return 1）。
+   - ヘルパー `_trace_traceability_healthy <body>`: `## Traceability` セクション内の `Intent refs:` / `Acceptance refs:` / `Verification:` の 3 フィールドが、いずれも「空白除去後に非空」かつ「`{{` プレースホルダを含まない」なら健全（return 0）。1 つでも欠ければ不備（return 1）。セクション開始条件は正規見出しの**完全一致** `## Traceability` に限定し（`## Traceability Notes` 等の別セクションを本物として集計しない）、正規セクション再入時にフィールドフラグをリセットして前段セクションの値で false OK にしない（codex review 指摘 #2 反映）。
    - 不備 work item の basename を `trace_bad_list` に集約。
 
 2. **done 集約**（work item 単位 / ループ内 / journal 整合用）:
@@ -33,7 +33,7 @@
 
 4. **journal 整合検証**（cycle 単位 / ループ後）:
    - `[[ ! -f "$CYCLE_DIR/journal.md" ]]` → `journal_missing=1`。
-   - 存在時は `journal_txt="$(cat "$CYCLE_DIR/journal.md")"` を取得し、`done_list` の各 basename（`.md` 除去）が journal 本文に含まれるか bash グロブ照合（`[[ "$journal_txt" == *"$name"* ]]`）。未記録の basename を `journal_uncovered_list` に集約。
+   - 存在時は `journal_txt="$(<"$CYCLE_DIR/journal.md")"` を取得し、`done` work item の各 basename（`.md` 除去）についてヘルパー `_trace_journal_has_record <journal_txt> <name>` で `- develop completed: <name>` 記録行の値を**完全一致**照合する（部分一致で `001-foo` が `001-foobar` に誤マッチして記録漏れを見逃さないよう、記録行から値を抽出して比較 / codex review 指摘 #1 反映）。未記録の basename を `journal_uncovered_list` に集約。
 
 ### 結果集約（単一 report）
 

--- a/.aidlc/cycles/v3.0.0-alpha.9/designs/001-doctor-trace-downstream.md
+++ b/.aidlc/cycles/v3.0.0-alpha.9/designs/001-doctor-trace-downstream.md
@@ -1,0 +1,63 @@
+# Design 001: doctor `[trace]` 後段検証拡充
+
+- trace: work item 001-doctor-trace-downstream
+- matrix_case: normal_standard
+- design_mode: simple
+
+## Goal
+
+`doctor.sh` の `diagnose_trace`（現状は design 要否 + `designs/<id>-<slug>.md` 存在確認まで）に、trace chain 後段の 3 検証（intent 存在 / Traceability 健全性 / journal 整合）を追加し、`[trace]` を read-only のまま深化させる。領域数は 11 のまま（領域追加ではなく `[trace]` 内の検証拡充）。
+
+## Context
+
+- 既存 `diagnose_trace`（`doctor.sh:453-533`）は、STATE_PRESENT / STATE_DERIVABLE / CYCLE_DIR / WORK_ITEMS_INVALID の前提ゲート通過後、work item を走査して §8 size×depth_level で design 要否を判定し、design 必須 work item の `designs/<basename>` 存在を確認して単一の `report trace WARN|OK` を出す。
+- 共有パーサ境界: frontmatter は `fm_extract_block` / `fm_scalar`（`lib/frontmatter.sh`）、本文は `fm_extract_body` を再利用する。**個別 consumer での raw grep/sed/awk による frontmatter/本文構造解釈は禁止**（`bin/check-frontmatter-parse-guard.sh` が doctor.sh を走査）。本文の Traceability 解析は bash 組込み（`while read` / `case` / パラメータ展開）+ `cat` のみで実装し、parse-guard のトークン検出（grep/sed/awk/jq）に一切触れない。
+- 後段検証の対象成果物（intent.md / journal.md）は define/develop の deliverable であり、その欠落は trace chain の破断を意味する。
+
+## Design
+
+### 検証の追加（すべて WARN 止まり / exit 0 維持 / read-only）
+
+既存ゲート（frontmatter 不在 / state なし / STATE_DERIVABLE / CYCLE_DIR / WORK_ITEMS_INVALID / work-items 不在・0 件）は変更しない。work item 走査ループを拡張し、走査後に 2 検証を追加する。
+
+1. **Traceability 健全性検証**（work item 単位 / ループ内）:
+   - `body="$(fm_extract_body "$f")"` で本文を取得。
+   - ヘルパー `_trace_traceability_healthy <body>`: `## Traceability` セクション内の `Intent refs:` / `Acceptance refs:` / `Verification:` の 3 フィールドが、いずれも「空白除去後に非空」かつ「`{{` プレースホルダを含まない」なら健全（return 0）。1 つでも欠ければ不備（return 1）。
+   - 不備 work item の basename を `trace_bad_list` に集約。
+
+2. **done 集約**（work item 単位 / ループ内 / journal 整合用）:
+   - `st="$(fm_scalar "$fm" status)"` で status を読取（frontmatter 再パースなし）。`done` の basename を `done_list` に集約。
+
+3. **intent.md 存在検証**（cycle 単位 / ループ後）:
+   - `[[ ! -f "$CYCLE_DIR/intent.md" ]]` → `intent_missing=1`。
+
+4. **journal 整合検証**（cycle 単位 / ループ後）:
+   - `[[ ! -f "$CYCLE_DIR/journal.md" ]]` → `journal_missing=1`。
+   - 存在時は `journal_txt="$(cat "$CYCLE_DIR/journal.md")"` を取得し、`done_list` の各 basename（`.md` 除去）が journal 本文に含まれるか bash グロブ照合（`[[ "$journal_txt" == *"$name"* ]]`）。未記録の basename を `journal_uncovered_list` に集約。
+
+### 結果集約（単一 report）
+
+既存の design 判定（`missing_list` / `invalid_list` / `warn_depth`）に上記後段結果を加え、**いずれかが非空なら単一の `report trace WARN`**、すべて充足なら `report trace OK` を出す（既存同様、行は 1 本）。detail は次元別トークンを連結:
+
+```
+trace 整合 WARN: design 欠落[...] risky×minimal[...] depth_level enum 外→standard \
+                 intent.md 欠落 Traceability 不備[...] journal.md 欠落 journal 未記録[...]
+```
+
+`depth_level enum 外→standard` トークンは既存テスト（`assert_area_detail trace "enum 外"`）互換のため文言を保持する。
+
+### 出力契約・exit code
+
+- `report trace <severity> <detail>`（`printf '%-14s%-6s%s'`）を厳守。severity は OK / WARN のみ（後段検証は ERROR / 診断不能を立てない）。
+- 総合 exit code 集約（`HAS_UNDIAGNOSABLE` > `HAS_ERROR` > 0）に影響を与えない（WARN は exit 0）。
+
+### コメント更新
+
+- ヘッダ [trace] wrap 契約コメント（`doctor.sh:36-38`）と `diagnose_trace` 関数コメント（`445-451`）を「design 要否 + 後段（intent/Traceability/journal）整合」に更新。領域数「11」は不変。
+
+### テスト（test-doctor.sh）
+
+- `make_valid_work_item` の `## Traceability` を健全内容（`Intent refs:` / `Acceptance refs:` / `Verification:` 非空・プレースホルダなし）に更新（work-item-validate は section 存在のみ検証のため valid 維持）。
+- `seed_cycle_meta <cycle_dir> [done_basenames...]` ヘルパーを追加し、intent.md と（done を記録した）journal.md を生成。
+- 既存「trace OK」/「全領域 OK」フィクスチャに `seed_cycle_meta` を適用（後段健全 → OK 維持）。
+- 新規ケース: intent.md 欠落 → WARN / Traceability プレースホルダ残存 → WARN / Traceability フィールド空 → WARN / journal.md 欠落 → WARN / done work item が journal 未記録 → WARN / 後段すべて健全 → OK。いずれも exit 0。

--- a/.aidlc/cycles/v3.0.0-alpha.9/intent.md
+++ b/.aidlc/cycles/v3.0.0-alpha.9/intent.md
@@ -1,0 +1,35 @@
+# Intent: v3.0.0-alpha.9
+
+## 目的
+
+v3 スキルの Phase 7-a セルフドッグフーディングとして、doctor `[trace]` 領域の後段検証（intent 存在・Traceability 健全性・journal 整合）を v3 フロー（define→develop→release→reflect）で 1 サイクル完走して実装し、v2 比の読込量・成果物数・確認回数の削減を測定して本流化条件の充足を確認する。
+
+## スコープ
+
+### 含むもの
+
+- `doctor.sh` の `diagnose_trace` 後段拡充（read-only 厳守）:
+  1. **intent.md 存在検証** — cycle に `intent.md` が存在するか（不在は WARN）
+  2. **Traceability 健全性検証** — 各 work item 本文 `## Traceability` の Intent refs / Acceptance refs / Verification が非空・プレースホルダ未置換でないか
+  3. **journal 整合検証** — `journal.md` 存在確認 + `status: done` work item が journal に記録されているか
+- `test-doctor.sh` の後段ケース拡張（各検証の OK / WARN 分岐）
+- ドッグフーディング測定記録（読込ファイル数・成果物数・確認回数の v2 比）を `journal.md` / `reflect.md` に収集
+
+### 含まないもの
+
+- Phase 7-b（`aidlc-v3 → aidlc` 置換・README 刷新・marketplace v3.0.0 化・v2→v3 migration） → 後続サイクル
+- reviews / release / reflect 相互の完全な意味的整合検証（今回は intent / Traceability / journal に限定）
+- doctor の自動修正機能（read-only 厳守を維持）
+
+## 受け入れ基準
+
+- [ ] AC-1: `diagnose_trace` に 3 後段検証が追加され、`[trace]` 領域として OK / WARN を出力（exit 0 維持 / read-only）
+- [ ] AC-2: `test-doctor.sh` が後段各ケース（正常 / intent 欠落 / プレースホルダ残存 / journal 未記録 / journal 不在）を検証しパス
+- [ ] AC-3: doctor が引き続き 11 領域構成（領域追加ではなく `[trace]` 内の検証深化）
+- [ ] AC-4: `reflect.md` に v2 比ドッグフーディング測定結果が記録される
+
+## 制約・前提
+
+- 実行経路 B（v3 ステップ手動駆動）。`/aidlc-v3` は現プラグインキャッシュ（commit `80c4fe62` = v2.6.6）に未含のため Skill 起動不可
+- 新規 frontmatter パース禁止（`lib/frontmatter.sh` 再利用）、`report()` 出力契約厳守
+- Epic #736（v3 リニューアル / Phase 7-a）に紐付く

--- a/.aidlc/cycles/v3.0.0-alpha.9/journal.md
+++ b/.aidlc/cycles/v3.0.0-alpha.9/journal.md
@@ -1,0 +1,13 @@
+# Journal: v3.0.0-alpha.9
+
+<!--
+追記型の軽量記録。日付見出し（## YYYY-MM-DD）配下に作業証跡を箇条書きで追記する。
+全 step の詳細記録は義務化しない（要点のみ）。次サイクルの define で参照可能にする。
+-->
+
+## 2026-07-02
+
+- define completed: intent and 1 work item created (001-doctor-trace-downstream / size: normal / risk: low)
+- Phase 7-a ドッグフーディング実行経路: B（v3 ステップ手動駆動 / `/aidlc-v3` は現プラグインキャッシュ未含のため Skill 起動不可）
+- dogfooding 測定①（define 開始時 AI 読込手順ファイル数）: v3 = 1（define.md のみ）/ v2 = 7（rules-core / preflight / session-continuity / index / 01-setup / task-management / version-check）
+- dogfooding 測定②（define ユーザー確認回数）: 2（Intent 承認ゲート / Work Item 承認ゲート）※方針確認（バージョン/スコープ/経路/work item）は v3 フロー外の事前ヒアリング

--- a/.aidlc/cycles/v3.0.0-alpha.9/journal.md
+++ b/.aidlc/cycles/v3.0.0-alpha.9/journal.md
@@ -11,3 +11,13 @@
 - Phase 7-a ドッグフーディング実行経路: B（v3 ステップ手動駆動 / `/aidlc-v3` は現プラグインキャッシュ未含のため Skill 起動不可）
 - dogfooding 測定①（define 開始時 AI 読込手順ファイル数）: v3 = 1（define.md のみ）/ v2 = 7（rules-core / preflight / session-continuity / index / 01-setup / task-management / version-check）
 - dogfooding 測定②（define ユーザー確認回数）: 2（Intent 承認ゲート / Work Item 承認ゲート）※方針確認（バージョン/スコープ/経路/work item）は v3 フロー外の事前ヒアリング
+
+## 2026-07-03
+
+- develop completed: 001-doctor-trace-downstream
+- develop パス: normal_standard（size normal × depth standard）→ 簡易 design（designs/001-...md）+ code review 経由で end-to-end 完走
+- 実装: doctor.sh diagnose_trace に後段3検証（intent 存在 / Traceability 健全性 / journal 整合）+ ヘルパー 3 関数。test-doctor.sh に後段8ケース追加
+- 検証: shellcheck clean / test-doctor.sh PASS 161 / parse-guard 違反なし / 実サイクル [trace] OK
+- レビュー: codex (gpt-5.5) code review。1回目 中2件（journal 部分一致 / Traceability Notes 誤検出）→ 修正 + 回帰テスト → 2回目 0件で auto_approved
+- dogfooding 測定③（develop 開始時 AI 読込手順ファイル数）: v3 = 1（develop.md / review 時に review-routing・review-flow を参照）
+- dogfooding 測定④（develop work item 成果物数）: 4（work-item 状態遷移 / designs/001 / reviews/001 / journal）。v2 Construction は ~8（domain-model / logical-design / plan / code / test / review-summary / history / progress 等）

--- a/.aidlc/cycles/v3.0.0-alpha.9/release.md
+++ b/.aidlc/cycles/v3.0.0-alpha.9/release.md
@@ -1,0 +1,65 @@
+# Release: v3.0.0-alpha.9
+
+<!--
+release フェーズ Step 2「PR 整備」で生成する成果物。
+PR 概要 / work item 完了一覧 / review 結果サマリ（機械可読）/ CI 状態 / merge 記録を集約する。
+-->
+
+## PR 概要
+
+- PR: #743
+- base: v3.0.0
+- head: cycle/v3.0.0-alpha.9
+- Phase 7-a セルフドッグフーディング。doctor `[trace]` 領域に trace chain 後段3検証（intent 存在 / Traceability 健全性 / journal 整合）を追加。read-only 厳守・共有パーサ再利用で parse-guard clean 維持。
+
+## Work Item 完了一覧
+
+| id | status | size |
+|----|--------|------|
+| 001 | done | normal |
+
+## Review 結果サマリ
+
+<!--
+固定マーカー間は純 YAML のみ。release Step 3 の merge ゲートがこの範囲を parse する（入力契約）。
+-->
+
+<!-- aidlc-release-review:start -->
+schema_version: "1.0"
+reviews:
+  - perspective: premerge
+    status: passed
+    unresolved_count: 0
+    max_severity: none
+    merge_blocker: false
+    skip_reason: null
+  - perspective: integration
+    status: skipped
+    unresolved_count: 0
+    max_severity: none
+    merge_blocker: false
+    skip_reason: "status:done が 1 件のため未実行（条件: 2 件以上）"
+  - perspective: deploy
+    status: skipped
+    unresolved_count: 0
+    max_severity: none
+    merge_blocker: false
+    skip_reason: "size:risky の done が 0 件のため未実行（条件: 1 件以上）"
+merge_blocker_any: false
+<!-- aidlc-release-review:end -->
+
+### premerge レビュー指摘と対応（codex gpt-5.5 / 全て解消済み → 未解決ブロッカー 0）
+
+- #1（高）: PR HEAD の state.json が pr_number: null → 本 Step で state.json を feature branch にコミットして PR に含めることで解消（フロー正常タイミング）。
+- #2（中）: design 成果物が旧実装（cat + 部分一致）記述 → design を最終実装（`$(<file)` + `_trace_journal_has_record` 完全一致 / 見出し完全一致 + リセット）に更新して解消。
+- #3（中）: intent AC-4 が reflect.md を参照するが本 PR 未含 → 非ブロッカー。reflect は本サイクル phase 4（release の後）の deliverable であり、測定は journal.md に記録済み。AC-4 は reflect フェーズで充足する phase-ordering。
+
+## CI 状態
+
+- conclusion: unavailable
+- 本リポジトリの CI workflow は全て `branches: [main]` トリガーで、base=`v3.0.0` 宛て PR では起動しない（required check 0 件）。v3 release フロー Step 3-4 hard gate（required 1 件以上 pass）とは不整合（Phase 7-a ドッグフーディング発見 / reflect で起票予定）。網羅的ローカル検証（v3 全11テストスイート pass / shellcheck / parse-guard / bash-substitution / defaults-sync / marketplace-version すべて green）を hard gate の代替根拠とし、ユーザー承認のもと adapted merge する（`v3.0.0` はブランチ保護なし / alpha.8 の v2 マージと同 precedent）。
+
+## Merge 記録
+
+- merge_approved: 未記録（Step 3 で記録）
+- merged: 未記録（Step 4 で記録）

--- a/.aidlc/cycles/v3.0.0-alpha.9/release.md
+++ b/.aidlc/cycles/v3.0.0-alpha.9/release.md
@@ -61,5 +61,5 @@ merge_blocker_any: false
 
 ## Merge 記録
 
-- merge_approved: 未記録（Step 3 で記録）
+- merge_approved: true（2026-07-03 / semi_auto auto-approve / merge_blocker_any=false）
 - merged: 未記録（Step 4 で記録）

--- a/.aidlc/cycles/v3.0.0-alpha.9/reviews/001-doctor-trace-downstream.md
+++ b/.aidlc/cycles/v3.0.0-alpha.9/reviews/001-doctor-trace-downstream.md
@@ -1,0 +1,32 @@
+# Review 001: doctor `[trace]` 後段検証拡充
+
+- trace: work item 001-doctor-trace-downstream
+- matrix_review_mode: code（focus: code, security）
+- tool: codex (gpt-5.5) / read-only sandbox
+
+<!-- aidlc-review:code:start status=complete -->
+## Code Review
+
+### 対象
+
+`skills/aidlc-v3/scripts/doctor.sh`（`diagnose_trace` 後段3検証追加）/ `skills/aidlc-v3/scripts/tests/test-doctor.sh`（フィクスチャ健全化 + 後段テスト追加）のワーキングツリー差分。
+
+### 指摘と対応（1 回目レビュー: 中 2 件 → 修正 → 2 回目レビュー: 0 件）
+
+- **指摘 #1（中 / code）**: journal 整合の done 照合が部分一致（`[[ "$journal_txt" == *"$name"* ]]`）で、`001-foo` が done のとき journal に `001-foobar` 等があるだけで「記録済み」と誤判定（記録漏れ見逃し）。
+  - **対応**: `_trace_journal_has_record` ヘルパーを新設。`- develop completed: <name>` 記録行から値を抽出し完全一致比較に変更。回帰テスト「journal に類似名記録のみ → done 未記録 WARN」を追加。
+- **指摘 #2（中 / code）**: Traceability セクション判定が prefix 一致（`"## Traceability"*`）で `## Traceability Notes` を本物として集計 + フラグが一度立つとリセットされず、後続の正規セクションの不備を false OK 化。
+  - **対応**: 開始条件を完全一致 `## Traceability` に限定し、正規セクション再入時に `_intent/_accept/_verify` をリセット。回帰テスト「Traceability Notes デコイ + 正規セクション不備 → WARN」を追加。
+
+### セキュリティ観点
+
+- read-only 厳守（state/work item/config 非変更）を確認。gh へ渡す値は本 work item では追加なし（[phase] 既存経路のみ）。
+- 本文解析は共有パーサ（`fm_extract_body` / `fm_scalar`）+ bash 組込みのみで、raw grep/sed/awk/permissive jq を使わず parse-guard clean を維持（インジェクション/構造解釈逸脱なし）。
+- journal 内容・Traceability 値・cycle 識別子は文字列比較のみで shell/gh へ渡さず、注入余地なし。機密情報のログ混入なし。
+- N/A: ネットワーク通信を行わないローカル CLI 診断のため、ネットワーク/HTTP 関連観点は N/A。
+
+### 最終判定
+
+2 回目レビューで指摘 0 件。unresolved_count=0（auto_approved 相当）。
+
+<!-- aidlc-review:code:end -->

--- a/.aidlc/cycles/v3.0.0-alpha.9/work-items/001-doctor-trace-downstream.md
+++ b/.aidlc/cycles/v3.0.0-alpha.9/work-items/001-doctor-trace-downstream.md
@@ -1,6 +1,6 @@
 ---
 id: "001"
-status: pending
+status: done
 size: normal
 risk: low
 assigned: null

--- a/.aidlc/cycles/v3.0.0-alpha.9/work-items/001-doctor-trace-downstream.md
+++ b/.aidlc/cycles/v3.0.0-alpha.9/work-items/001-doctor-trace-downstream.md
@@ -1,0 +1,49 @@
+---
+id: "001"
+status: pending
+size: normal
+risk: low
+assigned: null
+dependencies: []
+---
+
+# Work Item 001: doctor `[trace]` 後段検証拡充
+
+## Goal
+
+`doctor.sh` の `diagnose_trace` に trace chain 後段検証（intent 存在・Traceability 健全性・journal 整合）を追加し、read-only 診断の網羅性を高める。alpha.8 で design ファイル存在確認まで実装済みの `[trace]` を、後段の trace 整合まで深化させる。
+
+## Scope
+
+- 含むもの: `diagnose_trace` への 3 後段検証追加、`test-doctor.sh` の後段ケース拡張、`report()` 出力契約・11 領域構成の維持
+- 含まないもの: reviews / release / reflect の完全意味検証、doctor 自動修正、新規 frontmatter パーサ
+
+## Acceptance Criteria
+
+- [ ] intent.md 不在時に `[trace]` が WARN を出す（exit 0 維持）
+- [ ] work item の Traceability 各フィールド（Intent refs / Acceptance refs / Verification）が空 / プレースホルダ残存時に WARN
+- [ ] `status: done` work item が journal.md 未記録時に WARN、journal.md 不在時に WARN
+- [ ] 全後段検証充足時は既存同様 OK、`test-doctor.sh` 後段ケース全パス
+
+## Traceability
+
+- Intent refs: scope:doctor-trace-後段検証, scope:dogfooding測定
+- Acceptance refs: AC-1, AC-2, AC-3
+- Verification: bash skills/aidlc-v3/scripts/tests/test-doctor.sh
+- Release note required: no
+
+## Size / Risk
+
+- Size: normal
+- Risk: low
+- Reason: 既存のテスト済み `diagnose_trace` への additive・read-only 拡張で state / data を書き換えず、契約テストで担保されるため risk は low。ただし 3 サブ検証 + テスト拡張で単一関数の変更範囲を超えるため size は tiny ではなく normal。
+
+## Dependencies
+
+- none
+
+## Implementation Notes
+
+- 入力取得は既存スクリプト（`state-read.sh` / `work-item-status.sh`）と共有パーサ（`lib/frontmatter.sh` の `fm_scalar`）を再利用する（新規パース禁止規約）。
+- `report trace <severity> <detail>` の出力契約（`printf '%-14s%-6s%s'`）を厳守する。
+- WARN は exit 0、診断不能のみ exit 2 の総合 exit code 集約規約を踏襲する。

--- a/.aidlc/state.json
+++ b/.aidlc/state.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "3.0",
+  "current_cycle": "v3.0.0-alpha.9",
+  "define_completed": true,
+  "release": {
+    "pr_number": null,
+    "ready": false,
+    "merge_approved": false
+  },
+  "updated_at": "2026-07-02T07:52:28Z"
+}

--- a/.aidlc/state.json
+++ b/.aidlc/state.json
@@ -4,8 +4,8 @@
   "define_completed": true,
   "release": {
     "pr_number": 743,
-    "ready": false,
-    "merge_approved": false
+    "ready": true,
+    "merge_approved": true
   },
-  "updated_at": "2026-07-03T01:14:33Z"
+  "updated_at": "2026-07-03T01:20:42Z"
 }

--- a/.aidlc/state.json
+++ b/.aidlc/state.json
@@ -3,9 +3,9 @@
   "current_cycle": "v3.0.0-alpha.9",
   "define_completed": true,
   "release": {
-    "pr_number": null,
+    "pr_number": 743,
     "ready": false,
     "merge_approved": false
   },
-  "updated_at": "2026-07-02T07:52:28Z"
+  "updated_at": "2026-07-03T01:14:33Z"
 }

--- a/skills/aidlc-v3/scripts/doctor.sh
+++ b/skills/aidlc-v3/scripts/doctor.sh
@@ -33,9 +33,10 @@
 #                 state なし→OK（define フォールバック）/ work-items invalid→WARN /
 #                 complete は merge_approved=true + pr_number 非 null + gh で PR merged 確認成功時のみ→OK /
 #                 矛盾・確認不能（merge_approved×未 merged / define_completed 矛盾 等）→安全側導出 + WARN
-#   [trace]       data-model §8 size×depth_level で design 要否判定 + designs/<id>-<slug>.md 存在確認。
+#   [trace]       data-model §8 size×depth_level で design 要否判定 + designs/<id>-<slug>.md 存在確認、
+#                 加えて trace chain 後段（intent.md 存在 / work item Traceability 健全性 / journal 整合）を検証。
 #                 state/cycle/work-items 前提不足→SKIP / work-items invalid→WARN /
-#                 design 欠落・risky×minimal・depth_level enum 外→WARN（exit 0 維持）/ 充足→OK
+#                 design 欠落・risky×minimal・depth_level enum 外・後段不備→WARN（exit 0 維持）/ 充足→OK
 #   [scripts]     必須集合 全存在→OK / 欠落→ERROR
 #   [parse-guard] check-frontmatter-parse-guard.sh rc0→OK / rc1→ERROR / rc2→exit2
 #
@@ -445,11 +446,64 @@ diagnose_phase() {
 # ============================================================
 # [trace]
 # data-model.md §8 の size×depth_level マトリクスで design 要否を判定し、design 必須 work item に
-# 対応する designs/<id>-<slug>.md の存在を確認する（read-only）。
-# 欠落 / risky×minimal / depth_level enum 外は WARN（exit 0 維持）。ERROR/診断不能は立てない。
+# 対応する designs/<id>-<slug>.md の存在を確認する（read-only）。加えて trace chain 後段の 3 検証
+# （intent.md 存在 / work item Traceability の健全性 / journal 整合）を行い、chain の破断を WARN 化する。
+# 欠落 / risky×minimal / depth_level enum 外 / 後段不備は WARN（exit 0 維持）。ERROR/診断不能は立てない。
 # size enum 不正は上流 work-item-validate が ERROR 化 → WORK_ITEMS_INVALID ゲートで捕捉済み。
 # state が構造検証未通過（STATE_DERIVABLE!=1）のときは cycle コンテキストが信頼できないため導出不能。
+# 本文（Traceability）解析は共有パーサ（fm_extract_body）+ bash 組込みのみで行い、raw grep/sed/awk を
+# 使わない（parse-guard 規約 / lib/frontmatter.sh:24-30）。
 # ============================================================
+
+# _trace_field_ok <val> : 値が空白除去後に非空、かつ {{ プレースホルダを含まないなら return 0。
+_trace_field_ok() {
+    local _v="$1"
+    _v="${_v#"${_v%%[![:space:]]*}"}"   # 先頭空白除去
+    _v="${_v%"${_v##*[![:space:]]}"}"   # 末尾空白除去
+    [[ -n "$_v" && "$_v" != *"{{"* ]]
+}
+
+# _trace_traceability_healthy <body> : 本文の ## Traceability セクション内の
+#   Intent refs: / Acceptance refs: / Verification: が 3 つとも健全（_trace_field_ok）なら return 0。
+#   1 つでも欠ければ return 1。raw grep/sed/awk 不使用（bash case / パラメータ展開のみ / parse-guard 回避）。
+#   開始条件は正規見出しの完全一致（`## Traceability`）に限定し、`## Traceability Notes` 等の別セクションを
+#   本物として集計しない。正規セクション再入時はフラグをリセットし、前段セクションの値で false OK にしない。
+_trace_traceability_healthy() {
+    local _body="$1" _line _in=0 _intent=0 _accept=0 _verify=0
+    while IFS= read -r _line; do
+        case "$_line" in
+            "## Traceability") _in=1; _intent=0; _accept=0; _verify=0; continue ;;  # 正規見出し完全一致 / 再入でリセット
+            "## "*) _in=0 ;;                                                        # 次の h2 見出しで区間終了（h3 ### は非該当）
+        esac
+        [[ "$_in" -eq 1 ]] || continue
+        case "$_line" in
+            *"Intent refs:"*)     _trace_field_ok "${_line#*Intent refs:}"     && _intent=1 ;;
+            *"Acceptance refs:"*) _trace_field_ok "${_line#*Acceptance refs:}" && _accept=1 ;;
+            *"Verification:"*)    _trace_field_ok "${_line#*Verification:}"    && _verify=1 ;;
+        esac
+    done <<< "$_body"
+    [[ "$_intent" -eq 1 && "$_accept" -eq 1 && "$_verify" -eq 1 ]]
+}
+
+# _trace_journal_has_record <journal_txt> <name> : journal 本文に develop 完了記録行
+#   （"- develop completed: <name>"）が値完全一致で存在すれば return 0。記録行から値を抽出して
+#   完全一致比較し、部分一致（001-foo が 001-foobar に誤マッチ）による記録漏れ見逃しを防ぐ。
+#   raw grep/sed/awk 不使用（bash case / パラメータ展開のみ / parse-guard 回避）。
+_trace_journal_has_record() {
+    local _txt="$1" _name="$2" _line _rec
+    while IFS= read -r _line; do
+        case "$_line" in
+            *"develop completed:"*)
+                _rec="${_line#*develop completed:}"
+                _rec="${_rec#"${_rec%%[![:space:]]*}"}"   # 先頭空白除去
+                _rec="${_rec%"${_rec##*[![:space:]]}"}"   # 末尾空白除去
+                [[ "$_rec" == "$_name" ]] && return 0
+                ;;
+        esac
+    done <<< "$_txt"
+    return 1
+}
+
 diagnose_trace() {
     if ! declare -f fm_scalar >/dev/null 2>&1; then
         report trace WARN "lib/frontmatter.sh 不在のため trace 判定不能"
@@ -494,16 +548,19 @@ diagnose_trace() {
         minimal|standard|comprehensive) ;;
         *) warn_depth=1; depth="standard" ;;
     esac
-    # 各 work item の design 要否判定（design ファイルは work item と同じ basename）。
+    # 各 work item の design 要否判定（design ファイルは work item と同じ basename）+
+    # 後段: Traceability 健全性 / done 集約（journal 整合用）。
     local designs_dir="$CYCLE_DIR/designs"
-    local f base fm size required invalid_combo checked=0
-    local missing_list="" invalid_list=""
+    local f base fm size st body required invalid_combo checked=0
+    local missing_list="" invalid_list="" trace_bad_list=""
+    local -a done_arr=()
     for f in "${wi_files[@]}"; do
         [[ -e "$f" ]] || continue
         checked=$((checked + 1))
         base="$(basename "$f")"
         fm="$(fm_extract_block "$f")" || continue
         size="$(fm_scalar "$fm" size)" || size=""
+        st="$(fm_scalar "$fm" status)" || st=""
         required=0
         invalid_combo=0
         case "$size" in
@@ -520,15 +577,46 @@ diagnose_trace() {
         elif [[ "$required" -eq 1 && ! -f "$designs_dir/$base" ]]; then
             missing_list="$missing_list $base"
         fi
+        # 後段: Traceability 健全性（本文 ## Traceability の必須 3 フィールド）。
+        body="$(fm_extract_body "$f")" || body=""
+        if ! _trace_traceability_healthy "$body"; then
+            trace_bad_list="$trace_bad_list $base"
+        fi
+        # 後段: done work item を集約（journal 整合検証で使用）。
+        [[ "$st" == "done" ]] && done_arr+=("$base")
     done
-    if [[ -n "$missing_list" || -n "$invalid_list" || "$warn_depth" -eq 1 ]]; then
-        local detail="design 整合 WARN:"
+    # 後段: intent.md 存在（define deliverable / 欠落は trace chain 破断）。
+    local intent_missing=0
+    [[ -f "$CYCLE_DIR/intent.md" ]] || intent_missing=1
+    # 後段: journal 整合（journal.md 存在 + done work item の記録確認）。
+    local journal_missing=0 journal_uncovered_list="" journal_txt="" d name
+    local journal_file="$CYCLE_DIR/journal.md"
+    if [[ -f "$journal_file" ]]; then
+        journal_txt="$(<"$journal_file")"
+        if [[ "${#done_arr[@]}" -gt 0 ]]; then
+            for d in "${done_arr[@]}"; do
+                name="${d%.md}"
+                _trace_journal_has_record "$journal_txt" "$name" || journal_uncovered_list="$journal_uncovered_list $d"
+            done
+        fi
+    else
+        journal_missing=1
+    fi
+    # 結果集約（design 要否 + 後段 3 検証 / いずれか非空なら単一 WARN / read-only・exit 0 維持）。
+    if [[ -n "$missing_list" || -n "$invalid_list" || "$warn_depth" -eq 1 \
+          || -n "$trace_bad_list" || "$intent_missing" -eq 1 \
+          || "$journal_missing" -eq 1 || -n "$journal_uncovered_list" ]]; then
+        local detail="trace 整合 WARN:"
         [[ -n "$missing_list" ]] && detail="$detail design 欠落[${missing_list# }]"
         [[ -n "$invalid_list" ]] && detail="$detail risky×minimal[${invalid_list# }]"
         [[ "$warn_depth" -eq 1 ]] && detail="$detail depth_level enum 外→standard"
+        [[ "$intent_missing" -eq 1 ]] && detail="$detail intent.md 欠落"
+        [[ -n "$trace_bad_list" ]] && detail="$detail Traceability 不備[${trace_bad_list# }]"
+        [[ "$journal_missing" -eq 1 ]] && detail="$detail journal.md 欠落"
+        [[ -n "$journal_uncovered_list" ]] && detail="$detail journal 未記録[${journal_uncovered_list# }]"
         report trace WARN "$detail"
     else
-        report trace OK "design 要否充足（${checked} item(s)）"
+        report trace OK "trace 整合 OK（design 要否 + intent/Traceability/journal 充足 / ${checked} item(s)）"
     fi
 }
 

--- a/skills/aidlc-v3/scripts/tests/test-doctor.sh
+++ b/skills/aidlc-v3/scripts/tests/test-doctor.sh
@@ -160,7 +160,10 @@ scope
 
 ## Traceability
 
-- trace
+- Intent refs: scope:example
+- Acceptance refs: AC-001
+- Verification: test command
+- Release note required: no
 
 ## Size / Risk
 
@@ -170,6 +173,68 @@ size/risk
 
 none
 EOF
+}
+
+# Traceability フィールド値を指定して valid work item を生成する（[trace] 後段 Traceability 検証用）。
+#   make_work_item_trace <path> <id> <size> <status> <intent_val> <accept_val> <verify_val>
+# frontmatter・必須 6 セクションは work-item-validate valid を満たす。Traceability 3 フィールドのみ可変。
+make_work_item_trace() {
+    local path="$1" id="$2" size="$3" status="$4" iv="$5" av="$6" vv="$7"
+    cat > "$path" <<EOF
+---
+id: $id
+status: $status
+size: $size
+risk: low
+assigned: null
+dependencies: []
+---
+
+# work item $id
+
+## Goal
+
+goal
+
+## Scope
+
+scope
+
+## Acceptance Criteria
+
+- ac
+
+## Traceability
+
+- Intent refs: $iv
+- Acceptance refs: $av
+- Verification: $vv
+- Release note required: no
+
+## Size / Risk
+
+size/risk
+
+## Dependencies
+
+none
+EOF
+}
+
+# cycle メタ成果物（intent.md / journal.md）を seed する（[trace] 後段検証の充足用）。
+#   seed_cycle_meta <cycle_dir> [done_basename ...]
+# intent.md を作成し、journal.md に指定 done work item basename（.md 除去）の
+# develop completed 行を記録する（intent 存在 + journal 整合を満たす健全なメタ状態を作る）。
+seed_cycle_meta() {
+    local cycle_dir="$1"; shift
+    printf '%s\n' "# Intent" "" "目的" > "$cycle_dir/intent.md"
+    {
+        printf '%s\n' "# Journal" "" "## 2026-06-04" "" "- define completed"
+        local b
+        for b in "$@"; do
+            printf '%s\n' "- develop completed: ${b%.md}"
+        done
+    } > "$cycle_dir/journal.md"
 }
 
 # doctor を fixture 内で実行し、stdout を OUT / 終了コードを RC に格納する。
@@ -770,6 +835,7 @@ make_valid_state "$ROOT/.aidlc/state.json"
 mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items" "$ROOT/.aidlc/cycles/v3.0.0/designs"
 make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 normal pending
 : > "$ROOT/.aidlc/cycles/v3.0.0/designs/001-foo.md"
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0"
 git_init_clean "$ROOT"
 run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_OUT=standard
 assert_area trace OK "design 必須 × 存在は [trace] OK"
@@ -780,6 +846,7 @@ mk trace_required_missing
 make_valid_state "$ROOT/.aidlc/state.json"
 mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
 make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 normal pending
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0"
 git_init_clean "$ROOT"
 run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_OUT=standard
 assert_area trace WARN "design 必須 × 欠落は [trace] WARN"
@@ -790,6 +857,7 @@ mk trace_not_required
 make_valid_state "$ROOT/.aidlc/state.json"
 mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
 make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 tiny pending
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0"
 git_init_clean "$ROOT"
 run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_OUT=standard
 assert_area trace OK "tiny は design 不要で [trace] OK"
@@ -800,6 +868,7 @@ mk trace_comprehensive
 make_valid_state "$ROOT/.aidlc/state.json"
 mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
 make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 normal pending
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0"
 git_init_clean "$ROOT"
 run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_OUT=comprehensive
 assert_area trace WARN "normal × comprehensive は design 必須（欠落で WARN）"
@@ -810,6 +879,7 @@ mk trace_risky_minimal
 make_valid_state "$ROOT/.aidlc/state.json"
 mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
 make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 risky pending
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0"
 git_init_clean "$ROOT"
 run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_OUT=minimal
 assert_area trace WARN "risky × minimal は [trace] WARN（不正組み合わせ）"
@@ -820,6 +890,7 @@ mk trace_depth_unset
 make_valid_state "$ROOT/.aidlc/state.json"
 mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
 make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 normal pending
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0"
 git_init_clean "$ROOT"
 run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_RC=1
 assert_area trace WARN "depth_level 未設定は standard フォールバック（normal 欠落で WARN）"
@@ -830,6 +901,7 @@ mk trace_depth_enum_bad
 make_valid_state "$ROOT/.aidlc/state.json"
 mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
 make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 tiny pending
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0"
 git_init_clean "$ROOT"
 run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_OUT=deep
 assert_area trace WARN "depth_level enum 外は [trace] WARN（standard フォールバック + 警告）"
@@ -837,11 +909,154 @@ assert_area_detail trace "enum 外" "enum 外の警告根拠"
 assert_rc 0 "depth_level enum 外は総合 exit 0"
 
 # ------------------------------------------------------------
+echo "== [trace] 後段: intent 存在 / Traceability 健全性 / journal 整合 =="
+
+echo "-- 後段: intent.md 欠落 → WARN --"
+mk trace_intent_missing
+make_valid_state "$ROOT/.aidlc/state.json"
+mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
+make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 tiny pending
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0"
+rm -f "$ROOT/.aidlc/cycles/v3.0.0/intent.md"
+git_init_clean "$ROOT"
+run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_OUT=standard
+assert_area trace WARN "intent.md 欠落は [trace] WARN"
+assert_area_detail trace "intent.md 欠落" "intent 欠落の根拠"
+assert_rc 0 "intent.md 欠落は総合 exit 0"
+
+echo "-- 後段: Traceability プレースホルダ残存 → WARN --"
+mk trace_traceability_placeholder
+make_valid_state "$ROOT/.aidlc/state.json"
+mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
+make_work_item_trace "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 tiny pending "{{scope:example}}" "AC-001" "test command"
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0"
+git_init_clean "$ROOT"
+run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_OUT=standard
+assert_area trace WARN "Traceability プレースホルダ残存は [trace] WARN"
+assert_area_detail trace "Traceability 不備" "Traceability 不備の根拠"
+assert_rc 0 "Traceability 不備は総合 exit 0"
+
+echo "-- 後段: Traceability フィールド空 → WARN --"
+mk trace_traceability_empty
+make_valid_state "$ROOT/.aidlc/state.json"
+mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
+make_work_item_trace "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 tiny pending "scope:x" "AC-001" ""
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0"
+git_init_clean "$ROOT"
+run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_OUT=standard
+assert_area trace WARN "Traceability フィールド空は [trace] WARN"
+assert_rc 0 "Traceability フィールド空は総合 exit 0"
+
+echo "-- 後段: journal.md 欠落 → WARN --"
+mk trace_journal_missing
+make_valid_state "$ROOT/.aidlc/state.json"
+mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
+make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 tiny pending
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0"
+rm -f "$ROOT/.aidlc/cycles/v3.0.0/journal.md"
+git_init_clean "$ROOT"
+run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_OUT=standard
+assert_area trace WARN "journal.md 欠落は [trace] WARN"
+assert_area_detail trace "journal.md 欠落" "journal 欠落の根拠"
+assert_rc 0 "journal.md 欠落は総合 exit 0"
+
+echo "-- 後段: done work item が journal 未記録 → WARN --"
+mk trace_journal_uncovered
+make_valid_state "$ROOT/.aidlc/state.json"
+mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
+make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 tiny "done"
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0"
+git_init_clean "$ROOT"
+run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_OUT=standard
+assert_area trace WARN "done work item の journal 未記録は [trace] WARN"
+assert_area_detail trace "journal 未記録" "journal 未記録の根拠"
+assert_rc 0 "journal 未記録は総合 exit 0"
+
+echo "-- 後段: すべて健全（done を journal 記録）→ OK --"
+mk trace_downstream_ok
+make_valid_state "$ROOT/.aidlc/state.json"
+mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
+make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 tiny "done"
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0" "001-foo.md"
+git_init_clean "$ROOT"
+run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_OUT=standard
+assert_area trace OK "後段すべて健全は [trace] OK"
+assert_rc 0 "後段健全は総合 exit 0"
+
+echo "-- 後段: ## Traceability Notes デコイ + 正規 Traceability 不備 → WARN（完全一致・リセット / codex#2） --"
+mk trace_traceability_notes_decoy
+make_valid_state "$ROOT/.aidlc/state.json"
+mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
+cat > "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" <<'EOF'
+---
+id: 001
+status: pending
+size: tiny
+risk: low
+assigned: null
+dependencies: []
+---
+
+# work item 001
+
+## Goal
+
+goal
+
+## Scope
+
+scope
+
+## Acceptance Criteria
+
+- ac
+
+## Traceability Notes
+
+- Intent refs: decoy-value
+- Acceptance refs: decoy-value
+- Verification: decoy-value
+
+## Traceability
+
+- Intent refs: {{unfilled}}
+- Acceptance refs: AC-1
+- Verification: check
+
+## Size / Risk
+
+size/risk
+
+## Dependencies
+
+none
+EOF
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0"
+git_init_clean "$ROOT"
+run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_OUT=standard
+assert_area trace WARN "Traceability Notes デコイ後の正規セクション不備は [trace] WARN"
+assert_area_detail trace "Traceability 不備" "デコイに惑わされず正規セクションで不備検出"
+assert_rc 0 "デコイ + 正規不備は総合 exit 0"
+
+echo "-- 後段: journal に類似名記録のみ → done 未記録として WARN（完全一致 / codex#1） --"
+mk trace_journal_partial
+make_valid_state "$ROOT/.aidlc/state.json"
+mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
+make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 tiny "done"
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0" "001-foobar.md"
+git_init_clean "$ROOT"
+run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_OUT=standard
+assert_area trace WARN "類似名記録のみは done 未記録として [trace] WARN（完全一致）"
+assert_area_detail trace "journal 未記録" "部分一致で誤検出せず未記録判定"
+assert_rc 0 "類似名記録のみは総合 exit 0"
+
+# ------------------------------------------------------------
 echo "== 全領域 OK 正常系 → exit 0 =="
 mk all_ok
 make_valid_state "$ROOT/.aidlc/state.json"
 mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
 make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001
+seed_cycle_meta "$ROOT/.aidlc/cycles/v3.0.0"
 install_gh_stub "$ROOT" 0 "7"
 git_init_clean "$ROOT"
 run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH" DOCTOR_TEST_READCONFIG_RC=0 DOCTOR_TEST_PARSEGUARD_RC=0


### PR DESCRIPTION
## サイクル v3.0.0-alpha.9 — Phase 7-a セルフドッグフーディング + doctor `[trace]` 後段検証拡充

v3 リニューアル Phase 7-a（本流化前提）のセルフドッグフーディングとして、本サイクル自体を v3 スキル（`skills/aidlc-v3`）の define → develop → release フローで駆動した。実 work item として doctor `[trace]` 領域の後段検証を拡充。

Base: `v3.0.0`（alpha 統合ブランチ）/ Relates to #736

### work item 001: doctor `[trace]` 後段検証拡充

`doctor.sh` の `diagnose_trace`（従来は design 要否 + `designs/<id>-<slug>.md` 存在確認）に trace chain 後段の3検証を追加（read-only 厳守 / 領域数は 11 のまま深化）:

1. **intent.md 存在検証** — cycle に intent.md がなければ WARN
2. **Traceability 健全性検証** — work item 本文 `## Traceability` の Intent refs / Acceptance refs / Verification が空 or `{{` プレースホルダ残存なら WARN
3. **journal 整合検証** — journal.md 不在、または `status: done` work item が journal 未記録なら WARN

ヘルパー `_trace_field_ok` / `_trace_traceability_healthy` / `_trace_journal_has_record` を新設。本文解析は共有パーサ（`fm_extract_body` / `fm_scalar`）+ bash 組込みのみで、raw grep/sed/awk を使わず parse-guard clean を維持。

### レビュー

codex (gpt-5.5) code review を2巡。1巡目で中2件（journal 部分一致による誤マッチ / `## Traceability Notes` の誤検出 + フラグ非リセット）→ 完全一致比較・見出し完全一致・再入リセットで修正 + 回帰テスト2件追加 → 2巡目 指摘0件。

### 検証

- v3 全11テストスイート pass（`test-doctor.sh` PASS 161 / `test-develop-flow` PASS 191 等）
- shellcheck clean / parse-guard 違反なし / bash-substitution 違反なし / defaults-sync ok / marketplace-version（release-relevant 変更なし → bump 不要）
- 実サイクルで doctor `[trace]` OK

### ドッグフーディング測定（v2 比）

| 指標 | v3 | v2 |
|------|----|----|
| define/develop 読込手順ファイル | 各 1 | 7 / 5+ |
| develop work item 成果物数 | 4 | ~8 |
| フロー内ユーザー確認（承認ゲート） | 2 | 3+ |

読込量・成果物数ともに v2 比で明確に削減。

### 既知の統合ギャップ（reflect で起票予定）

v3 release フローの Step 3-4 hard gate は「統合ブランチに required CI がある」前提だが、本リポジトリの CI は全て `branches: [main]` トリガーで、v3.0.0 宛て PR では CI が起動しない（required 0 件）。本 PR は網羅的なローカル検証を hard gate の代替根拠として adapted merge する（alpha.8 の v2 マージと同 precedent）。
