### PR TITLE
[Release] v3.0.0-beta.2

### DIFF
--- a/.aidlc/cycles/v3.0.0-beta.2/designs/002-cycle-check-v3-flat.md
+++ b/.aidlc/cycles/v3.0.0-beta.2/designs/002-cycle-check-v3-flat.md
@@ -1,0 +1,69 @@
+# Design 002: cycle-phase-completion-check の v3-flat 構造対応
+
+- trace: work item 002-cycle-check-v3-flat
+- matrix_case: normal_standard
+- design_mode: simple
+
+## Goal
+
+`bin/check-cycle-phase-completion.sh` を v3-flat 構造（`intent.md` / `work-items/` + リポジトリ直下 `state.json`）で完了判定できるようにし、`cycle/*` 命名の v3 サイクル main 宛て PR が CI（`cycle-phase-completion-check.yml`）を通過できるようにする（#747）。v2 サイクル向けの既存判定は非影響で維持する。
+
+## Context
+
+- 既存 CLI は v2 構造（`inception/progress.md` / `story-artifacts/units/` / `operations/progress.md`）専用。v3-flat サイクルに実行すると `inception:incomplete:reason=progress_md_missing` で fail する。
+- CI workflow は `cycle/*` head branch の非 draft PR でのみ起動し、`--pr-number` に PR 番号を渡す。v2 判定は `AIDLC_CYCLES_BASE` 環境変数でフィクスチャ差し替え可能（bats 16 ケース既存）。
+- v3 のフェーズ導出正本は `docs/v3/data-model.md` §5.1（first-match）。本チェックは **merge 前の CI ゲート**であるため「complete（merged）」ではなく「**release 可能（評価順 4）+ release 記録あり**」を合格条件とする（merged を要求すると merge 前ゲートが恒久 fail する）。
+- v3 release フロー（`skills/aidlc-v3/steps/release.md`）では Step 2-2 で `release.pr_number` 記録、2-4 で `release.md` を head branch に commit + push、3-3 で `state.json` を含む最終 commit を push する。したがって PR の最終 head（merge 直前の hard gate 3-4 が見る SHA）では本設計の全条件が充足される。
+- リポジトリ設計原則「ドッグフーディング特殊処理を本体に埋めない」により、v2 / v3 の判別は **opt-in シグナル**（成果物の存在に基づく汎用分岐）で行う。starter kit 自身か否かの判定は導入しない。
+
+## Design
+
+### 1. 構造判別（opt-in シグナル方式）
+
+| シグナル | 判定 |
+|---------|------|
+| `<cycle_dir>/work-items/` ディレクトリが存在 | v3-flat 判定パスへ |
+| 上記なし | v2 判定パス（既存ロジック / 変更なし） |
+| `work-items/` と `inception/` が両方存在 | 曖昧構造として `error:ambiguous-cycle-structure` で exit 2（fail-closed） |
+
+v2 サイクルは `work-items/` を持たないため既存フィクスチャ・実サイクルの挙動は不変。consumer プロジェクトでも「成果物があれば v3 として判定」の汎用論理のみで動く。
+
+### 2. v3-flat 完了判定（評価順 / fail-fast で最初の未充足を報告）
+
+| # | 検査 | 未充足時の出力（exit 1） |
+|---|------|------------------------|
+| 1 | state file 存在（`AIDLC_STATE_FILE` 環境変数 / 既定 `${REPO_ROOT}/.aidlc/state.json`） | `v3:incomplete:reason=state_json_missing` |
+| 2 | `current_cycle` == CLI 引数 `<cycle>` | `v3:incomplete:reason=current_cycle_mismatch:expected=<cycle>:actual=<値>` |
+| 3 | `define_completed` == `true` | `v3:incomplete:reason=define_not_completed` |
+| 4 | `work-items/*.md` が 1 件以上 | `v3:incomplete:reason=no_work_items` |
+| 5 | 全 work item の frontmatter `status` が `done` / `withdrawn`（ソート順で最初の未完了を報告） | `v3:incomplete:reason=item_status_pending:item=<basename>:status=<値>` |
+| 6 | `release.md` が cycle dir に存在（release 記録） | `v3:incomplete:reason=release_md_missing` |
+| 7 | `release.pr_number` が正整数（null は未記録） | `v3:incomplete:reason=pr_number_not_recorded` |
+| 8 | `--pr-number N` 指定時、`release.pr_number` == N | `v3:incomplete:reason=pr_number_mismatch:expected=N:actual=<値>` |
+
+全充足で `v3:complete` を出力して exit 0。`ready` / `merge_approved` は要求しない（merge 前ゲートのため / merged 実態の検証は release Step 3-4 hard gate と doctor `[phase]` の責務）。
+
+### 3. パース・読取の安全境界（既存スクリプト再利用 / 生パース禁止）
+
+| 読取対象 | 使用スクリプト | 失敗時 |
+|---------|--------------|--------|
+| `state.json`（`current_cycle` / `define_completed` / `release.pr_number`） | `skills/aidlc-v3/scripts/state-read.sh <field> <file>`（file 引数で対象指定） | exit 1 → 判定不能として `v3:incomplete:reason=state_unreadable:field=<field>` exit 1 / exit 2（jq 不在等）→ exit 2 透過 |
+| work item `status` | `skills/aidlc-v3/scripts/work-item-status.sh --read <path>` | exit 1（malformed / enum 不正）→ `v3:incomplete:reason=work_item_malformed:item=<basename>` exit 1 / exit 2 → exit 2 透過 |
+
+frontmatter / JSON の生パース（grep/sed/awk/jq 直書き）を本 CLI に足さず、v3 の安全境界スクリプトへ委譲する（doctor / release フローと同じ読取経路 = 導出規則の再実装を避ける）。`bin/ → skills/` の依存は既存（`validate.sh` source 済み）と同方向。
+
+### 4. CLI インターフェース（後方互換）
+
+- 引数仕様（`<cycle>` / `--pr-number N` / `--help`）と exit code 規約（0 / 1 / 2）は不変。
+- 環境変数: 既存 `AIDLC_CYCLES_BASE` に加え、テスト用に `AIDLC_STATE_FILE`（v3 state file の場所差し替え / 既定はリポジトリ直下）を追加。
+- usage 文面に v3-flat 対応と `AIDLC_STATE_FILE` を追記。
+
+### 5. テスト（bats 追加 / 既存 16 ケース非影響）
+
+フィクスチャ: `tests/fixtures/cycle-phase-completion/v3-*/`（`state.json` + `cycles/<cycle>/` の 2 階層で `AIDLC_STATE_FILE` / `AIDLC_CYCLES_BASE` を差し替え）。
+
+追加ケース: (1) v3 全充足で exit 0 / (2) in_progress 残で exit 1 + 理由 / (3) release.md 欠落で exit 1 / (4) pr_number 未記録で exit 1 / (5) `--pr-number` 不一致で exit 1 / (6) current_cycle 不一致で exit 1 / (7) state.json 不在で exit 1 / (8) 曖昧構造（work-items/ + inception/ 両在）で exit 2 / (9) 既存 v2 ケース全 pass（回帰）。
+
+### 6. AC-5（実 PR での CI 成功）の充足経路
+
+本サイクル PR の**最終 head**（release Step 3-3 push 後）は「全 work item done + release.md + pr_number 記録」を満たすため、Step 3-4 hard gate が見る required check として本 job が成功する。develop 中のローカル実行では未充足理由（release_md_missing 等）を正しく報告する（これは正常動作）。

--- a/.aidlc/cycles/v3.0.0-beta.2/intent.md
+++ b/.aidlc/cycles/v3.0.0-beta.2/intent.md
@@ -1,0 +1,32 @@
+# Intent: v3.0.0-beta.2
+
+## 目的
+
+v3 ベータの既知バグと CI 非互換を解消し、v3 サイクルが `cycle/*` 命名の main 宛て PR で自走できる状態にする（#744 / #747）。
+
+## スコープ
+
+### 含むもの
+
+- #744: doctor `[phase]` の complete 判定を `gh pr view --json state`（`.state == "MERGED"`）ベースに修正（`skills/aidlc-v3/scripts/doctor.sh` の `diagnose_phase`）
+- #744: `test-doctor.sh` の gh stub（`install_gh_stub_full`）を実 gh の JSON フィールド（`state` / `mergedAt`）に忠実化し、テスト忠実性ギャップを解消
+- #747: `bin/check-cycle-phase-completion.sh` の v3-flat 構造対応（v2 サイクルの既存判定は非影響で維持）
+
+### 含まないもの
+
+- #745（release hard gate の required CI 0 件時フォールバック方針）→ Phase 7 前の後続サイクルへ defer
+- v2 → v3 migration / 本流化（Phase 7）そのもの
+- doctor の自動修正機能（read-only 維持）
+
+## 受け入れ基準
+
+- [ ] AC-1: merge 済みサイクルに対し doctor `[phase]` が `complete` を正しく導出する（実環境 gh で確認）
+- [ ] AC-2: gh stub が実 gh の JSON フィールドに忠実で、`test-doctor.sh` 全ケース pass（`--json merged` 依存の残存なし）
+- [ ] AC-3: `check-cycle-phase-completion.sh` が v3-flat サイクルの完了判定を行え、v2 サイクル向け既存判定・既存テストに非影響
+- [ ] AC-4: 本サイクル自身の PR（`cycle/v3.0.0-beta.2` → main）で cycle-phase-completion-check job が成功する
+- [ ] AC-5: 全テストスイート / shellcheck / parse-guard が green
+
+## 制約・前提
+
+- 「ドッグフーディング特殊処理を本体に埋めない」原則に従い、#747 の構造判別は opt-in シグナル方式（成果物の存在に基づく汎用分岐）を優先する
+- doctor / チェックスクリプトは自動修正しない（診断・判定のみ）

--- a/.aidlc/cycles/v3.0.0-beta.2/journal.md
+++ b/.aidlc/cycles/v3.0.0-beta.2/journal.md
@@ -11,3 +11,9 @@
 - スコープ: #744（doctor [phase] merged 判定修正 + gh stub 忠実化）+ #747（cycle-phase-completion-check の v3-flat 対応）。#745 は Phase 7 前の後続サイクルへ defer
 - 実行経路: `/aidlc-v3`（Skill 起動 / plugin cache 7ea41a179688 = v3.0.0-beta.1 同梱版）。前サイクル alpha.9 の経路 B（手動駆動）から Skill 起動へ移行
 - 前サイクル state.json（alpha.9 / complete 導出・PR #743 merged 確認済み）を削除して state-init.sh で再生成（create-only 仕様のため / ユーザー承認済み）
+
+## 2026-07-04
+
+- develop completed: 001-doctor-phase-merged-fix
+- doctor.sh の [phase] complete 判定を gh に存在しない `--json merged` から `--json state`（.state == "MERGED"）へ修正（#744）。test-doctor.sh の install_gh_stub_full を実 gh 忠実化（state/mergedAt 以外のフィールド指定は unknown JSON field エラー exit 1）し、フィールド名不正をテストで検出可能にした
+- 検証: alpha.9 相当フィクスチャ + 実環境 gh で [phase] OK complete（PR #743 merged）導出を確認 / test-doctor.sh 161 ケース pass / shellcheck・parse-guard clean / `--json merged` 残存なし

--- a/.aidlc/cycles/v3.0.0-beta.2/journal.md
+++ b/.aidlc/cycles/v3.0.0-beta.2/journal.md
@@ -1,0 +1,13 @@
+# Journal: v3.0.0-beta.2
+
+<!--
+追記型の軽量記録。日付見出し（## YYYY-MM-DD）配下に作業証跡を箇条書きで追記する。
+全 step の詳細記録は義務化しない（要点のみ）。次サイクルの define で参照可能にする。
+-->
+
+## 2026-07-03
+
+- define completed: intent and 2 work items created (001-doctor-phase-merged-fix / tiny / low, 002-cycle-check-v3-flat / normal / medium)
+- スコープ: #744（doctor [phase] merged 判定修正 + gh stub 忠実化）+ #747（cycle-phase-completion-check の v3-flat 対応）。#745 は Phase 7 前の後続サイクルへ defer
+- 実行経路: `/aidlc-v3`（Skill 起動 / plugin cache 7ea41a179688 = v3.0.0-beta.1 同梱版）。前サイクル alpha.9 の経路 B（手動駆動）から Skill 起動へ移行
+- 前サイクル state.json（alpha.9 / complete 導出・PR #743 merged 確認済み）を削除して state-init.sh で再生成（create-only 仕様のため / ユーザー承認済み）

--- a/.aidlc/cycles/v3.0.0-beta.2/journal.md
+++ b/.aidlc/cycles/v3.0.0-beta.2/journal.md
@@ -17,3 +17,7 @@
 - develop completed: 001-doctor-phase-merged-fix
 - doctor.sh の [phase] complete 判定を gh に存在しない `--json merged` から `--json state`（.state == "MERGED"）へ修正（#744）。test-doctor.sh の install_gh_stub_full を実 gh 忠実化（state/mergedAt 以外のフィールド指定は unknown JSON field エラー exit 1）し、フィールド名不正をテストで検出可能にした
 - 検証: alpha.9 相当フィクスチャ + 実環境 gh で [phase] OK complete（PR #743 merged）導出を確認 / test-doctor.sh 161 ケース pass / shellcheck・parse-guard clean / `--json merged` 残存なし
+- develop completed: 002-cycle-check-v3-flat
+- check-cycle-phase-completion.sh に v3-flat 判定を追加（#747）。構造判別は opt-in シグナル（work-items/ の存在 / 曖昧構造は exit 2 fail-closed）、完了条件は data-model §5.1 評価順 4 + release 記録（release.md + pr_number）。state.json / frontmatter の読取は v3 安全境界スクリプト（state-read.sh / work-item-status.sh）へ委譲
+- 検証: bats 24 ケース pass（既存 v2 16 ケース回帰含む）/ 実 v2.6.6 exit 0 / 実 beta.2 は item_status_pending を正しく報告 / alpha.9 + 相当 state で v3:complete exit 0 / shellcheck 新規指摘なし / parse-guard clean。AC-5（実 PR での CI job 成功）は release フェーズの最終 head で確認する
+- code review（codex 外部 CLI / required / 2 Round）: R1 フィクスチャ未追跡 → staging で解消 / R2 「develop 途中はゲートが block」→ by-design（release 最終 head で充足 / design §6）。unresolved_count=0 → auto_approved

--- a/.aidlc/cycles/v3.0.0-beta.2/release.md
+++ b/.aidlc/cycles/v3.0.0-beta.2/release.md
@@ -78,5 +78,5 @@ premerge（codex / 高 1 件）・integration（codex / 中 1 件）の指摘は
 
 <!-- merge 記録は release Step 3/4 で追記する（テンプレート生成時点では未記録）。 -->
 
-- merge_approved: 未記録（Step 3 で記録）
+- merge_approved: true（2026-07-04 / semi_auto 自動承認: merge_blocker_any=false）
 - merged: 未記録（Step 4 で記録）

--- a/.aidlc/cycles/v3.0.0-beta.2/release.md
+++ b/.aidlc/cycles/v3.0.0-beta.2/release.md
@@ -1,0 +1,82 @@
+# Release: v3.0.0-beta.2
+
+<!--
+release フェーズ Step 2「PR 整備」で生成する成果物。
+PR 概要 / work item 完了一覧 / review 結果サマリ（機械可読）/ CI 状態 / merge 記録を集約する。
+release-level review（premerge / integration / deploy）の結果は本ファイルに集約し reviews/*.md は生成しない
+（docs/v3/data-model.md §8 / §10）。merge 記録は Step 3/4 で追記する。
+-->
+
+## PR 概要
+
+- PR: #748
+- base: main
+- head: cycle/v3.0.0-beta.2
+- v3 ベータの既知バグと CI 非互換を解消する: doctor `[phase]` の merged 判定を `gh pr view --json state` ベースへ修正し gh stub を忠実化（#744）、`bin/check-cycle-phase-completion.sh` を v3-flat 構造対応（#747）。
+
+## Work Item 完了一覧
+
+| id | status | size |
+|----|--------|------|
+| 001-doctor-phase-merged-fix | done | tiny |
+| 002-cycle-check-v3-flat | done | normal |
+
+<!--
+全 work item が done / withdrawn（release 可能 / docs/v3/data-model.md §5.1 評価順 4）であることを Step 1 で確認済み。
+本表は done / withdrawn の内訳を記録する。
+-->
+
+## Review 結果サマリ
+
+<!--
+固定マーカー間（start の次行から end の前行まで）は純 YAML のみ。release Step 3 の merge ゲートがこの範囲を
+そのまま YAML として parse する（入力契約）。マーカー間に markdown コードフェンス・見出し・装飾を置かないこと。
+status: passed | failed | skipped / max_severity: high | medium | low | none。
+status=skipped は skip_reason を非 null にする（実行条件未該当の理由）。
+merge_blocker は当該 perspective に高重要度（high）の未解決指摘があれば true。
+merge_blocker_any はいずれかの perspective が merge_blocker=true なら true。
+マーカー不在・純 YAML として parse 不能・必須フィールド欠落・enum 外は release Step 3 側で fail-closed。
+-->
+
+<!-- aidlc-release-review:start -->
+schema_version: "1.0"
+reviews:
+  - perspective: premerge
+    status: passed
+    unresolved_count: 0
+    max_severity: none
+    merge_blocker: false
+    skip_reason: null
+  - perspective: integration
+    status: passed
+    unresolved_count: 0
+    max_severity: none
+    merge_blocker: false
+    skip_reason: null
+  - perspective: deploy
+    status: skipped
+    unresolved_count: 0
+    max_severity: none
+    merge_blocker: false
+    skip_reason: "size:risky の done が 0 件のため未実行（条件: 1 件以上）"
+merge_blocker_any: false
+<!-- aidlc-release-review:end -->
+
+<!--
+premerge（codex / 高 1 件）・integration（codex / 中 1 件）の指摘はいずれも
+「release.md 未追加 + state.json の release.pr_number 未反映で cycle-phase-completion-check が exit 1 になる」
+という同一論点であり、本 release.md と state.json（release.pr_number: 748）を head branch に commit することで解消済み
+（bin/check-cycle-phase-completion.sh v3.0.0-beta.2 --pr-number 748 の exit 0 で検証）。設計乖離の指摘なし。
+-->
+
+## CI 状態
+
+- conclusion: pending
+- Step 1 時点で cycle/v3.0.0-beta.2 の run は未実行（gh run list 0 件 / CI は PR イベントで起動）。CI パスの強制は Step 3 hard gate（gh pr checks --required）で行う。
+
+## Merge 記録
+
+<!-- merge 記録は release Step 3/4 で追記する（テンプレート生成時点では未記録）。 -->
+
+- merge_approved: 未記録（Step 3 で記録）
+- merged: 未記録（Step 4 で記録）

--- a/.aidlc/cycles/v3.0.0-beta.2/reviews/002-cycle-check-v3-flat.md
+++ b/.aidlc/cycles/v3.0.0-beta.2/reviews/002-cycle-check-v3-flat.md
@@ -1,0 +1,27 @@
+# Review 002: cycle-phase-completion-check の v3-flat 構造対応
+
+- trace: work item 002-cycle-check-v3-flat
+- matrix_case: normal_standard
+- matrix_review_mode: code
+
+<!-- aidlc-review:code:start status=complete -->
+## Code Review
+
+- 実行経路: 外部 CLI（codex review --base main / stdin ガード付き）/ routing_review_mode=required / focus: code, security
+- 反復: 2 Round / unresolved_count=0
+
+### Round 1（指摘 1 件 → 解消）
+
+- [P1] 新規 bats ケースが参照する v3 フィクスチャが diff に含まれていない
+  - 対応: フィクスチャは作成済みだが未追跡だったため codex の diff に写っていなかった。`git add -A` で staging し、Round 2 の diff に含めて解消（Round 2 で再指摘なし）。work item 単位 commit（Step 6）に含まれる。
+
+### Round 2（指摘 1 件 → by-design 解消）
+
+- [P1] 本サイクル（v3.0.0-beta.2）の work item 002 が in_progress のままでは新ゲートが PR を block する
+  - 対応: 設計どおりの動作（defect ではない）。本 work item の status は develop Step 6 で done へ遷移し、release.md / release.pr_number は release フェーズ（Step 2-2 / 2-4）で head branch に commit される。CI job は draft PR を skip し、merge 判定に効く最終 head（release Step 3-3 push 後）では全条件が充足される。充足経路は design（002-cycle-check-v3-flat.md §6「AC-5 の充足経路」）に明記済み。develop 途中の incomplete 報告（item_status_pending）はゲートの正しい振る舞いであり、ローカル実行で期待どおりの理由出力を確認済み。
+
+### セキュリティ観点
+
+- 指摘なし。cycle 引数は既存 `validate_cycle_input`（パストラバーサル / 制御文字 reject）を通過後にのみパス構築に使用。state.json / frontmatter の読取は v3 安全境界スクリプト（state-read.sh / work-item-status.sh）へ委譲し、生パースを追加していない。曖昧構造（v2 / v3 シグナル両在）は fail-closed（exit 2）。
+
+<!-- aidlc-review:code:end -->

--- a/.aidlc/cycles/v3.0.0-beta.2/work-items/001-doctor-phase-merged-fix.md
+++ b/.aidlc/cycles/v3.0.0-beta.2/work-items/001-doctor-phase-merged-fix.md
@@ -1,0 +1,43 @@
+---
+id: "001"
+status: pending
+size: tiny
+risk: low
+assigned: null
+dependencies: []
+---
+
+# Work Item 001: doctor [phase] merged 判定修正 + gh stub 忠実化
+
+## Goal
+
+doctor `[phase]` の complete 判定が gh に存在しない `--json merged` フィールドを使い常に失敗するバグ（#744）を修正し、PR merged 確認を `--json state`（`.state == "MERGED"`）ベースに変更する。併せて `test-doctor.sh` の gh stub を実 gh の JSON フィールドに忠実化し、フィールド名不正を検出できなかったテスト忠実性ギャップを解消する。
+
+## Scope
+
+- 含むもの: `skills/aidlc-v3/scripts/doctor.sh` の `diagnose_phase`（merged 確認箇所）の修正、`test-doctor.sh` の `install_gh_stub_full`（および関連ケース）の `state` / `mergedAt` ベースへの忠実化、回帰テスト
+- 含まないもの: doctor の他領域（`[trace]` 等）の変更、自動修正機能、`reflect.md` Step 0 側（既に `--json state,mergedAt` 使用で正しい）
+
+## Acceptance Criteria
+
+- [ ] merge 済みサイクル（例: alpha.9 / PR #743）に対し `doctor.sh` の `[phase]` が `complete` を OK で導出する（実環境 gh で確認）
+- [ ] `doctor.sh` / `test-doctor.sh` に `--json merged` への依存が残存しない
+- [ ] gh stub が実 gh の応答形式（`state` / `mergedAt`）を模し、`test-doctor.sh` 全ケース pass
+- [ ] shellcheck / parse-guard clean
+
+## Traceability
+
+- Intent refs: scope:#744（doctor complete 判定修正 / gh stub 忠実化）
+- Acceptance refs: AC-1, AC-2, AC-5
+- Verification: `bash skills/aidlc-v3/scripts/tests/test-doctor.sh` + 実サイクルへの `doctor.sh` 実行
+- Release note required: yes（既知制約 #744 の解消）
+
+## Size / Risk
+
+- Size: tiny
+- Risk: low
+- Reason: 修正方法が Issue #744 で確定済みで変更が局所的。既存回帰テストスイート（161 ケース）で保護されている
+
+## Dependencies
+
+- none

--- a/.aidlc/cycles/v3.0.0-beta.2/work-items/001-doctor-phase-merged-fix.md
+++ b/.aidlc/cycles/v3.0.0-beta.2/work-items/001-doctor-phase-merged-fix.md
@@ -1,6 +1,6 @@
 ---
 id: "001"
-status: pending
+status: done
 size: tiny
 risk: low
 assigned: null

--- a/.aidlc/cycles/v3.0.0-beta.2/work-items/002-cycle-check-v3-flat.md
+++ b/.aidlc/cycles/v3.0.0-beta.2/work-items/002-cycle-check-v3-flat.md
@@ -1,6 +1,6 @@
 ---
 id: "002"
-status: pending
+status: done
 size: normal
 risk: medium
 assigned: null

--- a/.aidlc/cycles/v3.0.0-beta.2/work-items/002-cycle-check-v3-flat.md
+++ b/.aidlc/cycles/v3.0.0-beta.2/work-items/002-cycle-check-v3-flat.md
@@ -1,0 +1,44 @@
+---
+id: "002"
+status: pending
+size: normal
+risk: medium
+assigned: null
+dependencies: []
+---
+
+# Work Item 002: cycle-phase-completion-check の v3-flat 構造対応
+
+## Goal
+
+`bin/check-cycle-phase-completion.sh`（CI: `cycle-phase-completion-check.yml`）を v3-flat 構造（`intent.md` / `work-items/` + リポジトリ直下 `state.json`）で完了判定できるようにし、`cycle/*` 命名の v3 サイクル main 宛て PR が CI を通過できるようにする（#747）。v2 サイクル向けの既存判定は非影響で維持する。
+
+## Scope
+
+- 含むもの: v3-flat サイクルの完了判定ロジック追加（`state.json` + work item frontmatter ベース / doctor `[phase]` の導出規則 data-model.md §5 と整合）、v2 / v3 の構造判別（opt-in シグナル方式 = 成果物の存在に基づく汎用分岐）、テスト追加
+- 含まないもの: v2 判定ロジックの変更、CI workflow のトリガー条件変更（`cycle/*` ガードは維持）、#745（hard gate 方針）
+
+## Acceptance Criteria
+
+- [ ] v3-flat サイクル（全 work item done/withdrawn + release 記録あり）に対し complete 判定が exit 0 で通る
+- [ ] v3-flat サイクルの未完了状態（pending/in_progress の work item あり等)で incomplete 判定（exit 1）と理由が出力される
+- [ ] v2 サイクルに対する既存判定の挙動・既存テストが非影響（全 pass）
+- [ ] 構造判別に「starter kit 自身か」の判定を埋め込まない（opt-in シグナル方式 / リポジトリ設計原則準拠）
+- [ ] 本サイクル自身の PR（`cycle/v3.0.0-beta.2` → main）で cycle-phase-completion-check job が成功する
+
+## Traceability
+
+- Intent refs: scope:#747（check-cycle-phase-completion の v3-flat 対応）
+- Acceptance refs: AC-3, AC-4, AC-5
+- Verification: 既存テスト + v3-flat ケース追加分の実行、`bash bin/check-cycle-phase-completion.sh v3.0.0-beta.2` のローカル実行、本サイクル PR での実 CI
+- Release note required: yes（既知制約 #747 の解消）
+
+## Size / Risk
+
+- Size: normal
+- Risk: medium
+- Reason: 対応案（v3 判定の追加方式 / 判別シグナル設計）の設計選択を伴い、CI マージゲートに関わるため。簡易 design 経由で実装する
+
+## Dependencies
+
+- none

--- a/.aidlc/state.json
+++ b/.aidlc/state.json
@@ -3,9 +3,9 @@
   "current_cycle": "v3.0.0-beta.2",
   "define_completed": true,
   "release": {
-    "pr_number": null,
+    "pr_number": 748,
     "ready": false,
     "merge_approved": false
   },
-  "updated_at": "2026-07-03T12:31:06Z"
+  "updated_at": "2026-07-03T16:00:19Z"
 }

--- a/.aidlc/state.json
+++ b/.aidlc/state.json
@@ -4,8 +4,8 @@
   "define_completed": true,
   "release": {
     "pr_number": 748,
-    "ready": false,
-    "merge_approved": false
+    "ready": true,
+    "merge_approved": true
   },
-  "updated_at": "2026-07-03T16:00:19Z"
+  "updated_at": "2026-07-03T16:10:31Z"
 }

--- a/.aidlc/state.json
+++ b/.aidlc/state.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "3.0",
-  "current_cycle": "v3.0.0-alpha.9",
+  "current_cycle": "v3.0.0-beta.2",
   "define_completed": true,
   "release": {
-    "pr_number": 743,
-    "ready": true,
-    "merge_approved": true
+    "pr_number": null,
+    "ready": false,
+    "merge_approved": false
   },
-  "updated_at": "2026-07-03T01:20:42Z"
+  "updated_at": "2026-07-03T12:31:06Z"
 }

--- a/bin/check-cycle-phase-completion.sh
+++ b/bin/check-cycle-phase-completion.sh
@@ -3,9 +3,12 @@
 #
 # cycle/* PR の 3 Phase（Inception / Construction / Operations）完了状態を CI で検証する CLI。
 # Unit 001 / Issue #672 / v2.5.6
+# Issue #747 / v3.0.0-beta.2: v3-flat 構造（work-items/ + リポジトリ直下 state.json）の
+#   完了判定を追加。構造判別は opt-in シグナル（<cycle>/work-items/ の存在）で行う。
 #
 # 入力契約: bare cycle ID（例: v2.5.6 / waf/v1.0.0）。`cycle/` prefix を含む値は reject。
-# 詳細は .aidlc/cycles/v2.5.6/design-artifacts/logical-designs/unit_001_*.md 参照。
+# 詳細は .aidlc/cycles/v2.5.6/design-artifacts/logical-designs/unit_001_*.md および
+# .aidlc/cycles/v3.0.0-beta.2/designs/002-cycle-check-v3-flat.md 参照。
 set -eu
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -13,19 +16,36 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # shellcheck source=../skills/aidlc/scripts/lib/validate.sh
 . "${REPO_ROOT}/skills/aidlc/scripts/lib/validate.sh"
 
+# v3 の state.json / work item frontmatter の読取は v3 の安全境界スクリプトへ委譲する
+# （生 jq / grep / sed / awk パースを本 CLI に足さない）。
+readonly V3_STATE_READ="${REPO_ROOT}/skills/aidlc-v3/scripts/state-read.sh"
+readonly V3_WORK_ITEM_STATUS="${REPO_ROOT}/skills/aidlc-v3/scripts/work-item-status.sh"
+
 usage() {
     cat <<'USAGE'
 Usage: check-cycle-phase-completion.sh <cycle> [--pr-number N] [--help]
 
-Verify that all 3 phases (Inception / Construction / Operations) are complete
-for the given cycle.
+Verify that the given cycle is complete before merging its PR.
+
+Structure detection (opt-in signal):
+  <cycle_dir>/work-items/ exists  -> v3-flat evaluation (state.json +
+                                     work item frontmatter + release.md)
+  otherwise                       -> v2 evaluation (Inception / Construction /
+                                     Operations progress artifacts)
+  both work-items/ and inception/ -> ambiguous structure, exit 2
 
 Arguments:
   <cycle>           bare cycle ID (e.g. v2.5.6, waf/v1.0.0)
                     NOTE: must NOT include the leading 'cycle/' prefix
   --pr-number N     expected PR number (positive integer); when given, the
-                    Operations phase additionally verifies pr_number value match
+                    Operations phase (v2) / release record (v3) additionally
+                    verifies pr_number value match
   --help            print this message and exit 0
+
+Environment:
+  AIDLC_CYCLES_BASE cycles base directory override (tests)
+  AIDLC_STATE_FILE  v3 state.json path override (tests);
+                    default: <repo>/.aidlc/state.json
 
 Exit codes:
   0  all 3 phases complete
@@ -341,6 +361,128 @@ evaluate_operations() {
     return 0
 }
 
+# Evaluate v3-flat cycle completion (opt-in signal: work-items/ directory).
+# CI gate semantics: "release-ready + release record" (data-model.md §5.1
+# evaluation order 4, plus release.md / release.pr_number). Merged state is NOT
+# required because this check runs before merge; merged verification belongs to
+# the release Step 3-4 hard gate and doctor [phase].
+# $1: cycle ID
+# $2: cycle directory path
+# $3: expected_pr_number (empty = not specified)
+# stdout: PhaseCompletionStatus message
+# return: 0 complete, 1 incomplete, 2 system error
+evaluate_v3_flat() {
+    local cycle="$1" cycle_dir="$2" expected_pr="${3:-}"
+    local state_file="${AIDLC_STATE_FILE:-${REPO_ROOT}/.aidlc/state.json}"
+
+    if [[ ! -f "${state_file}" ]]; then
+        echo "v3:incomplete:reason=state_json_missing"
+        return 1
+    fi
+
+    local rc value
+
+    rc=0
+    value="$("${V3_STATE_READ}" current_cycle "${state_file}" 2>/dev/null)" || rc=$?
+    case "${rc}" in
+        0) ;;
+        2)
+            echo "error:v3-state-read-failed:field=current_cycle:detail=system"
+            return 2
+            ;;
+        *)
+            echo "v3:incomplete:reason=state_unreadable:field=current_cycle"
+            return 1
+            ;;
+    esac
+    if [[ "${value}" != "${cycle}" ]]; then
+        echo "v3:incomplete:reason=current_cycle_mismatch:expected=${cycle}:actual=${value}"
+        return 1
+    fi
+
+    rc=0
+    value="$("${V3_STATE_READ}" define_completed "${state_file}" 2>/dev/null)" || rc=$?
+    case "${rc}" in
+        0) ;;
+        2)
+            echo "error:v3-state-read-failed:field=define_completed:detail=system"
+            return 2
+            ;;
+        *)
+            echo "v3:incomplete:reason=state_unreadable:field=define_completed"
+            return 1
+            ;;
+    esac
+    if [[ "${value}" != "true" ]]; then
+        echo "v3:incomplete:reason=define_not_completed:actual=${value}"
+        return 1
+    fi
+
+    # All work items must be done / withdrawn (data-model.md §5.1 order 4).
+    local wi_dir="${cycle_dir}/work-items"
+    if [[ -z "$(find "${wi_dir}" -maxdepth 1 -type f -name '*.md' -print -quit 2>/dev/null)" ]]; then
+        echo "v3:incomplete:reason=no_work_items"
+        return 1
+    fi
+
+    local wi_file wi_basename status_out status
+    while IFS= read -r wi_file; do
+        wi_basename="$(basename "${wi_file}" .md)"
+        rc=0
+        status_out="$("${V3_WORK_ITEM_STATUS}" --read "${wi_file}" 2>/dev/null)" || rc=$?
+        case "${rc}" in
+            0) ;;
+            2)
+                echo "error:v3-work-item-read-failed:item=${wi_basename}:detail=system"
+                return 2
+                ;;
+            *)
+                echo "v3:incomplete:reason=work_item_malformed:item=${wi_basename}"
+                return 1
+                ;;
+        esac
+        status="${status_out#status:}"
+        case "${status}" in
+            done|withdrawn) ;;
+            *)
+                echo "v3:incomplete:reason=item_status_pending:item=${wi_basename}:status=${status}"
+                return 1
+                ;;
+        esac
+    done < <(find "${wi_dir}" -maxdepth 1 -type f -name '*.md' | sort)
+
+    # Release record: release.md artifact + recorded PR number.
+    if [[ ! -f "${cycle_dir}/release.md" ]]; then
+        echo "v3:incomplete:reason=release_md_missing"
+        return 1
+    fi
+
+    rc=0
+    value="$("${V3_STATE_READ}" release.pr_number "${state_file}" 2>/dev/null)" || rc=$?
+    case "${rc}" in
+        0) ;;
+        2)
+            echo "error:v3-state-read-failed:field=release.pr_number:detail=system"
+            return 2
+            ;;
+        *)
+            echo "v3:incomplete:reason=state_unreadable:field=release.pr_number"
+            return 1
+            ;;
+    esac
+    if [[ ! "${value}" =~ ^[1-9][0-9]*$ ]]; then
+        echo "v3:incomplete:reason=pr_number_not_recorded:actual=${value}"
+        return 1
+    fi
+    if [[ -n "${expected_pr}" ]] && [[ "${value}" != "${expected_pr}" ]]; then
+        echo "v3:incomplete:reason=pr_number_mismatch:expected=${expected_pr}:actual=${value}"
+        return 1
+    fi
+
+    echo "v3:complete"
+    return 0
+}
+
 main() {
     local cycle="" expected_pr=""
 
@@ -402,6 +544,18 @@ main() {
     if [[ ! -d "${cycle_dir}" ]]; then
         echo "error:cycle-not-found:${cycle_dir}"
         return 2
+    fi
+
+    # Structure detection (opt-in signal): a v3-flat cycle carries work-items/.
+    # Ambiguity (both v3 work-items/ and v2 inception/ present) is fail-closed.
+    if [[ -d "${cycle_dir}/work-items" ]]; then
+        if [[ -d "${cycle_dir}/inception" ]]; then
+            echo "error:ambiguous-cycle-structure:${cycle_dir}:detail=both-v2-and-v3-signals-present"
+            return 2
+        fi
+        local v3_rc=0
+        evaluate_v3_flat "${cycle}" "${cycle_dir}" "${expected_pr}" || v3_rc=$?
+        return "${v3_rc}"
     fi
 
     # Fail-fast: stop on first incomplete phase.

--- a/skills/aidlc-v3/scripts/doctor.sh
+++ b/skills/aidlc-v3/scripts/doctor.sh
@@ -390,9 +390,9 @@ diagnose_phase() {
     # 渡す前に正整数を必須検証する（gh 引数注入余地の排除 / 不一致は complete 非導出 + WARN）。
     if [[ "$merge_approved" == "true" ]]; then
         if [[ "$pr_number" =~ ^[1-9][0-9]*$ && "$GH_AVAILABLE" -eq 1 ]]; then
-            local merged
-            merged="$(gh pr view "$pr_number" --json merged --jq '.merged' 2>/dev/null)" || merged=""
-            if [[ "$merged" == "true" ]]; then
+            local pr_state
+            pr_state="$(gh pr view "$pr_number" --json state --jq '.state' 2>/dev/null)" || pr_state=""
+            if [[ "$pr_state" == "MERGED" ]]; then
                 report phase OK "complete（merge_approved=true + PR #${pr_number} merged）"
                 return
             fi

--- a/skills/aidlc-v3/scripts/tests/test-doctor.sh
+++ b/skills/aidlc-v3/scripts/tests/test-doctor.sh
@@ -320,11 +320,14 @@ STUB
     chmod +x "$root/bin/gh"
 }
 
-# gh stub（[phase] complete 確認用 / auth + pr list + pr view --json merged を制御）。
-#   install_gh_stub_full <root> <auth_rc> <pr_numbers> <pr_view_merged>
-#     pr_view_merged: `gh pr view <n> --json merged --jq '.merged'` が返す値（true/false 等）
+# gh stub（[phase] complete 確認用 / auth + pr list + pr view --json state を制御）。
+#   install_gh_stub_full <root> <auth_rc> <pr_numbers> <pr_view_state>
+#     pr_view_state: `gh pr view <n> --json state --jq '.state'` が返す値（MERGED / OPEN / CLOSED）
+#   実 gh 忠実化（#744）: pr view の --json に実 gh に存在しないフィールド（例: merged）が
+#   指定された場合、実 gh と同様に unknown JSON field エラー（exit 1）を返す。
+#   これによりフィールド名不正が stub 経由のテストで検出可能になる。
 install_gh_stub_full() {
-    local root="$1" auth_rc="$2" pr_numbers="$3" pr_view_merged="$4"
+    local root="$1" auth_rc="$2" pr_numbers="$3" pr_view_state="$4"
     cat > "$root/bin/gh" <<STUB
 #!/usr/bin/env bash
 case "\$1" in
@@ -333,8 +336,21 @@ case "\$1" in
     ;;
   pr)
     if [ "\$2" = "view" ]; then
-      # gh pr view <n> --json merged --jq '.merged'
-      echo "$pr_view_merged"
+      # gh pr view <n> --json <fields> --jq '...'
+      json_fields=""
+      expect_json=0
+      for arg in "\$@"; do
+        if [ "\$expect_json" = 1 ]; then json_fields="\$arg"; expect_json=0; continue; fi
+        [ "\$arg" = "--json" ] && expect_json=1
+      done
+      IFS=',' read -r -a fields <<< "\$json_fields"
+      for f in "\${fields[@]}"; do
+        case "\$f" in
+          state|mergedAt) : ;;
+          *) echo "unknown JSON field: \\"\$f\\"" >&2; exit 1 ;;
+        esac
+      done
+      echo "$pr_view_state"
       exit 0
     fi
     # gh pr list --state open --json number --jq '...'
@@ -677,7 +693,7 @@ jq '.define_completed = true | .release.merge_approved = true | .release.pr_numb
 mv "$ROOT/.aidlc/state.json.tmp" "$ROOT/.aidlc/state.json"
 mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
 make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 tiny "done"
-install_gh_stub_full "$ROOT" 0 "42" "true"
+install_gh_stub_full "$ROOT" 0 "42" "MERGED"
 git_init_clean "$ROOT"
 run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH"
 assert_area phase OK "merge_approved + PR merged は [phase] OK（complete）"
@@ -692,7 +708,7 @@ jq '.define_completed = true | .release.merge_approved = true | .release.pr_numb
 mv "$ROOT/.aidlc/state.json.tmp" "$ROOT/.aidlc/state.json"
 mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
 make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 tiny "done"
-install_gh_stub_full "$ROOT" 0 "42" "false"
+install_gh_stub_full "$ROOT" 0 "42" "OPEN"
 git_init_clean "$ROOT"
 run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH"
 assert_area phase WARN "merge_approved=true × 未 merged は [phase] WARN"
@@ -706,7 +722,7 @@ jq '.define_completed = true | .release.merge_approved = true' \
 mv "$ROOT/.aidlc/state.json.tmp" "$ROOT/.aidlc/state.json"
 mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
 make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 tiny pending
-install_gh_stub_full "$ROOT" 0 "" "false"
+install_gh_stub_full "$ROOT" 0 "" "OPEN"
 git_init_clean "$ROOT"
 run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH"
 assert_area phase WARN "merge_approved=true × pr_number=null は [phase] WARN"
@@ -720,7 +736,7 @@ jq '.define_completed = true | .release.merge_approved = true | .release.pr_numb
 mv "$ROOT/.aidlc/state.json.tmp" "$ROOT/.aidlc/state.json"
 mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
 make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 tiny pending
-install_gh_stub_full "$ROOT" 0 "" "true"   # gh は使われない（pr_number=0 で検証弾き）
+install_gh_stub_full "$ROOT" 0 "" "MERGED"   # gh は使われない（pr_number=0 で検証弾き）
 git_init_clean "$ROOT"
 run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH"
 assert_area phase WARN "merge_approved=true × pr_number=0 は [phase] WARN（0 は不正 PR 番号）"
@@ -734,7 +750,7 @@ jq '.define_completed = true | .release.merge_approved = true | .release.pr_numb
 mv "$ROOT/.aidlc/state.json.tmp" "$ROOT/.aidlc/state.json"
 mkdir -p "$ROOT/.aidlc/cycles/v3.0.0/work-items"
 make_valid_work_item "$ROOT/.aidlc/cycles/v3.0.0/work-items/001-foo.md" 001 tiny pending
-install_gh_stub_full "$ROOT" 1 "42" "true"   # auth rc1 → GH_AVAILABLE=0（complete 確認不能）
+install_gh_stub_full "$ROOT" 1 "42" "MERGED"   # auth rc1 → GH_AVAILABLE=0（complete 確認不能）
 git_init_clean "$ROOT"
 run_doctor "$DOCTOR" "$ROOT" PATH="$ROOT/bin:$PATH"
 assert_area phase WARN "merge_approved=true × gh 不可は [phase] WARN（complete 確認不能）"

--- a/tests/check-cycle-phase-completion.bats
+++ b/tests/check-cycle-phase-completion.bats
@@ -132,3 +132,71 @@ setup() {
     [ "$status" -eq 1 ]
     [[ "$output" != *"operations:complete"* ]]
 }
+
+# --- v3-flat structure (Issue #747 / v3.0.0-beta.2 Work Item 002) ---
+# v3 tests always set AIDLC_STATE_FILE explicitly so the repository's real
+# .aidlc/state.json is never read (test isolation).
+
+# (q) v3 complete
+@test "v3-flat complete: 全 work item done/withdrawn + release 記録で exit 0" {
+    export AIDLC_STATE_FILE="${AIDLC_CYCLES_BASE}/v3-complete/state.json"
+    run "${CLI}" v3-complete --pr-number 755
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"v3:complete"* ]]
+}
+
+# (r) v3 incomplete: work item in_progress
+@test "v3-flat 未完: in_progress の work item で exit 1 + 理由出力" {
+    export AIDLC_STATE_FILE="${AIDLC_CYCLES_BASE}/v3-item-pending/state.json"
+    run "${CLI}" v3-item-pending
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"v3:incomplete:reason=item_status_pending:item=002-bar:status=in_progress"* ]]
+}
+
+# (s) v3 incomplete: release.md missing
+@test "v3-flat release.md 欠落: release_md_missing で exit 1" {
+    export AIDLC_STATE_FILE="${AIDLC_CYCLES_BASE}/v3-release-md-missing/state.json"
+    run "${CLI}" v3-release-md-missing
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"v3:incomplete:reason=release_md_missing"* ]]
+}
+
+# (t) v3 incomplete: pr_number not recorded (null)
+@test "v3-flat pr_number 未記録: null で exit 1" {
+    export AIDLC_STATE_FILE="${AIDLC_CYCLES_BASE}/v3-pr-not-recorded/state.json"
+    run "${CLI}" v3-pr-not-recorded
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"v3:incomplete:reason=pr_number_not_recorded:actual=null"* ]]
+}
+
+# (u) v3 incomplete: --pr-number mismatch
+@test "v3-flat pr_number 不一致: --pr-number 999 で exit 1" {
+    export AIDLC_STATE_FILE="${AIDLC_CYCLES_BASE}/v3-complete/state.json"
+    run "${CLI}" v3-complete --pr-number 999
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"v3:incomplete:reason=pr_number_mismatch:expected=999:actual=755"* ]]
+}
+
+# (v) v3 incomplete: current_cycle mismatch
+@test "v3-flat current_cycle 不一致: state.json が別サイクルを指す場合 exit 1" {
+    export AIDLC_STATE_FILE="${AIDLC_CYCLES_BASE}/v3-cycle-mismatch/state.json"
+    run "${CLI}" v3-cycle-mismatch
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"v3:incomplete:reason=current_cycle_mismatch:expected=v3-cycle-mismatch:actual=v3-other"* ]]
+}
+
+# (w) v3 incomplete: state.json missing
+@test "v3-flat state.json 不在: state_json_missing で exit 1" {
+    export AIDLC_STATE_FILE="${AIDLC_CYCLES_BASE}/v3-complete/does-not-exist.json"
+    run "${CLI}" v3-complete
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"v3:incomplete:reason=state_json_missing"* ]]
+}
+
+# (x) ambiguous structure: both v3 (work-items/) and v2 (inception/) signals
+@test "曖昧構造: work-items/ と inception/ 両在で exit 2" {
+    export AIDLC_STATE_FILE="${AIDLC_CYCLES_BASE}/v3-complete/state.json"
+    run "${CLI}" v3-ambiguous
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"error:ambiguous-cycle-structure"* ]]
+}

--- a/tests/fixtures/cycle-phase-completion/v3-ambiguous/inception/progress.md
+++ b/tests/fixtures/cycle-phase-completion/v3-ambiguous/inception/progress.md
@@ -1,0 +1,9 @@
+# Inception Phase 進捗管理
+
+ambiguous-structure fixture (v2 signal).
+
+## ステップ一覧
+
+| ステップ | 状態 | 成果物 | 完了日 |
+|---------|------|--------|--------|
+| 1. Intent明確化 | 完了 | requirements/intent.md | 2026-07-04 |

--- a/tests/fixtures/cycle-phase-completion/v3-ambiguous/work-items/001-foo.md
+++ b/tests/fixtures/cycle-phase-completion/v3-ambiguous/work-items/001-foo.md
@@ -1,0 +1,12 @@
+---
+id: "001"
+status: done
+size: tiny
+risk: low
+assigned: null
+dependencies: []
+---
+
+# Work Item 001: foo
+
+ambiguous-structure fixture (v3 signal).

--- a/tests/fixtures/cycle-phase-completion/v3-complete/release.md
+++ b/tests/fixtures/cycle-phase-completion/v3-complete/release.md
@@ -1,0 +1,3 @@
+# Release: v3-complete
+
+v3-flat fixture release record.

--- a/tests/fixtures/cycle-phase-completion/v3-complete/state.json
+++ b/tests/fixtures/cycle-phase-completion/v3-complete/state.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "3.0",
+  "current_cycle": "v3-complete",
+  "define_completed": true,
+  "release": {
+    "pr_number": 755,
+    "ready": true,
+    "merge_approved": false
+  },
+  "updated_at": "2026-07-04T00:00:00Z"
+}

--- a/tests/fixtures/cycle-phase-completion/v3-complete/work-items/001-foo.md
+++ b/tests/fixtures/cycle-phase-completion/v3-complete/work-items/001-foo.md
@@ -1,0 +1,12 @@
+---
+id: "001"
+status: done
+size: tiny
+risk: low
+assigned: null
+dependencies: []
+---
+
+# Work Item 001: foo
+
+v3-flat fixture (done).

--- a/tests/fixtures/cycle-phase-completion/v3-complete/work-items/002-bar.md
+++ b/tests/fixtures/cycle-phase-completion/v3-complete/work-items/002-bar.md
@@ -1,0 +1,12 @@
+---
+id: "002"
+status: withdrawn
+size: normal
+risk: low
+assigned: null
+dependencies: []
+---
+
+# Work Item 002: bar
+
+v3-flat fixture (withdrawn).

--- a/tests/fixtures/cycle-phase-completion/v3-cycle-mismatch/release.md
+++ b/tests/fixtures/cycle-phase-completion/v3-cycle-mismatch/release.md
@@ -1,0 +1,3 @@
+# Release: v3-cycle-mismatch
+
+v3-flat fixture release record.

--- a/tests/fixtures/cycle-phase-completion/v3-cycle-mismatch/state.json
+++ b/tests/fixtures/cycle-phase-completion/v3-cycle-mismatch/state.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "3.0",
+  "current_cycle": "v3-other",
+  "define_completed": true,
+  "release": {
+    "pr_number": 755,
+    "ready": false,
+    "merge_approved": false
+  },
+  "updated_at": "2026-07-04T00:00:00Z"
+}

--- a/tests/fixtures/cycle-phase-completion/v3-cycle-mismatch/work-items/001-foo.md
+++ b/tests/fixtures/cycle-phase-completion/v3-cycle-mismatch/work-items/001-foo.md
@@ -1,0 +1,12 @@
+---
+id: "001"
+status: done
+size: tiny
+risk: low
+assigned: null
+dependencies: []
+---
+
+# Work Item 001: foo
+
+v3-flat fixture (done).

--- a/tests/fixtures/cycle-phase-completion/v3-item-pending/release.md
+++ b/tests/fixtures/cycle-phase-completion/v3-item-pending/release.md
@@ -1,0 +1,3 @@
+# Release: v3-item-pending
+
+v3-flat fixture release record.

--- a/tests/fixtures/cycle-phase-completion/v3-item-pending/state.json
+++ b/tests/fixtures/cycle-phase-completion/v3-item-pending/state.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "3.0",
+  "current_cycle": "v3-item-pending",
+  "define_completed": true,
+  "release": {
+    "pr_number": 755,
+    "ready": false,
+    "merge_approved": false
+  },
+  "updated_at": "2026-07-04T00:00:00Z"
+}

--- a/tests/fixtures/cycle-phase-completion/v3-item-pending/work-items/001-foo.md
+++ b/tests/fixtures/cycle-phase-completion/v3-item-pending/work-items/001-foo.md
@@ -1,0 +1,12 @@
+---
+id: "001"
+status: done
+size: tiny
+risk: low
+assigned: null
+dependencies: []
+---
+
+# Work Item 001: foo
+
+v3-flat fixture (done).

--- a/tests/fixtures/cycle-phase-completion/v3-item-pending/work-items/002-bar.md
+++ b/tests/fixtures/cycle-phase-completion/v3-item-pending/work-items/002-bar.md
@@ -1,0 +1,12 @@
+---
+id: "002"
+status: in_progress
+size: normal
+risk: low
+assigned: null
+dependencies: []
+---
+
+# Work Item 002: bar
+
+v3-flat fixture (in_progress).

--- a/tests/fixtures/cycle-phase-completion/v3-pr-not-recorded/release.md
+++ b/tests/fixtures/cycle-phase-completion/v3-pr-not-recorded/release.md
@@ -1,0 +1,3 @@
+# Release: v3-pr-not-recorded
+
+v3-flat fixture release record.

--- a/tests/fixtures/cycle-phase-completion/v3-pr-not-recorded/state.json
+++ b/tests/fixtures/cycle-phase-completion/v3-pr-not-recorded/state.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "3.0",
+  "current_cycle": "v3-pr-not-recorded",
+  "define_completed": true,
+  "release": {
+    "pr_number": null,
+    "ready": false,
+    "merge_approved": false
+  },
+  "updated_at": "2026-07-04T00:00:00Z"
+}

--- a/tests/fixtures/cycle-phase-completion/v3-pr-not-recorded/work-items/001-foo.md
+++ b/tests/fixtures/cycle-phase-completion/v3-pr-not-recorded/work-items/001-foo.md
@@ -1,0 +1,12 @@
+---
+id: "001"
+status: done
+size: tiny
+risk: low
+assigned: null
+dependencies: []
+---
+
+# Work Item 001: foo
+
+v3-flat fixture (done).

--- a/tests/fixtures/cycle-phase-completion/v3-release-md-missing/state.json
+++ b/tests/fixtures/cycle-phase-completion/v3-release-md-missing/state.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "3.0",
+  "current_cycle": "v3-release-md-missing",
+  "define_completed": true,
+  "release": {
+    "pr_number": 755,
+    "ready": false,
+    "merge_approved": false
+  },
+  "updated_at": "2026-07-04T00:00:00Z"
+}

--- a/tests/fixtures/cycle-phase-completion/v3-release-md-missing/work-items/001-foo.md
+++ b/tests/fixtures/cycle-phase-completion/v3-release-md-missing/work-items/001-foo.md
@@ -1,0 +1,12 @@
+---
+id: "001"
+status: done
+size: tiny
+risk: low
+assigned: null
+dependencies: []
+---
+
+# Work Item 001: foo
+
+v3-flat fixture (done).


### PR DESCRIPTION
# Release: v3.0.0-beta.2

## 目的

v3 ベータの既知バグと CI 非互換を解消し、v3 サイクルが `cycle/*` 命名の main 宛て PR で自走できる状態にする（#744 / #747）。

## Work Items

| ID | 内容 | status | size |
|----|------|--------|------|
| 001-doctor-phase-merged-fix | doctor `[phase]` merged 判定を `--json state` ベースへ修正 + gh stub 忠実化（#744） | done | tiny |
| 002-cycle-check-v3-flat | `bin/check-cycle-phase-completion.sh` の v3-flat 構造対応（#747） | done | normal |

## Release-level Review

| perspective | status | 備考 |
|-------------|--------|------|
| premerge（codex） | passed | 高 1 件 → release.md + state.json の commit で解消済み |
| integration（codex） | passed | 中 1 件（同一論点）→ 同上で解消済み / 設計乖離なし |
| deploy | skipped | risky work item なし |

## テスト・検証

- bats テストスイート: 731 / 731 pass（skip 2 件は意図的スキップ）
- cycle-phase-completion-check: `v3:complete`（exit 0 / AC-4 充足）

## 成果物

- `.aidlc/cycles/v3.0.0-beta.2/release.md`（review 結果サマリ / merge 記録）
