### PR TITLE
release: v3.0.0-beta.2 post-merge bookkeeping

### DIFF
--- a/.aidlc/cycles/v3.0.0-beta.2/journal.md
+++ b/.aidlc/cycles/v3.0.0-beta.2/journal.md
@@ -21,3 +21,5 @@
 - check-cycle-phase-completion.sh に v3-flat 判定を追加（#747）。構造判別は opt-in シグナル（work-items/ の存在 / 曖昧構造は exit 2 fail-closed）、完了条件は data-model §5.1 評価順 4 + release 記録（release.md + pr_number）。state.json / frontmatter の読取は v3 安全境界スクリプト（state-read.sh / work-item-status.sh）へ委譲
 - 検証: bats 24 ケース pass（既存 v2 16 ケース回帰含む）/ 実 v2.6.6 exit 0 / 実 beta.2 は item_status_pending を正しく報告 / alpha.9 + 相当 state で v3:complete exit 0 / shellcheck 新規指摘なし / parse-guard clean。AC-5（実 PR での CI job 成功）は release フェーズの最終 head で確認する
 - code review（codex 外部 CLI / required / 2 Round）: R1 フィクスチャ未追跡 → staging で解消 / R2 「develop 途中はゲートが block」→ by-design（release 最終 head で充足 / design §6）。unresolved_count=0 → auto_approved
+- release completed: v3.0.0-beta.2 (PR #748 merged)
+- release 詳細: bats 731 全 pass / premerge・integration review（codex）は「release.md 未 commit で CI ゲート exit 1」の同一論点のみ → release.md + state.json commit で解消（v3:complete exit 0 = AC-4 充足）/ deploy review は risky なしで skipped / semi_auto 自動承認 → hard gate（required 5 件 pass + CLEAN）→ merge commit c0b3f09a

--- a/.aidlc/cycles/v3.0.0-beta.2/release.md
+++ b/.aidlc/cycles/v3.0.0-beta.2/release.md
@@ -79,4 +79,4 @@ premerge（codex / 高 1 件）・integration（codex / 中 1 件）の指摘は
 <!-- merge 記録は release Step 3/4 で追記する（テンプレート生成時点では未記録）。 -->
 
 - merge_approved: true（2026-07-04 / semi_auto 自動承認: merge_blocker_any=false）
-- merged: 未記録（Step 4 で記録）
+- merged: true（2026-07-03T16:27:35Z / merge commit c0b3f09a02092b09fa09b81a5098a5a0b01b2f37 / merge method: merge）

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI-DLC (AI-Driven Development Lifecycle) skills for Claude Code",
-    "version": "3.0.0-beta.1"
+    "version": "3.0.0-beta.2"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ AI-DLC Starter Kit の変更履歴です。
 
 ---
 
+## [3.0.0-beta.2] - 2026-07-04
+
+v3 ベータの既知バグと CI 非互換を解消し、v3 サイクルが `cycle/*` 命名の main 宛て PR で自走できる状態にする（#744 / #747）。本サイクル自体を v3 スキル（`/aidlc-v3`）の define → develop → release フローで駆動（セルフドッグフーディング継続）。v2（`/aidlc`）には非影響。
+
+### Fixed
+
+- **doctor `[phase]` merged 判定修正 + gh stub 忠実化（#744）**: `doctor.sh` の `[phase]` complete 判定が gh に存在しない `--json merged` フィールドを使い常に失敗するバグを修正し、PR merged 確認を `--json state`（`.state == "MERGED"`）ベースへ変更。併せて `test-doctor.sh` の gh stub（`install_gh_stub_full`）を実 gh の JSON フィールド（`state` / `mergedAt`）に忠実化し、フィールド名不正を検出できなかったテスト忠実性ギャップを解消
+
+### Added
+
+- **cycle-phase-completion-check の v3-flat 構造対応（#747）**: `bin/check-cycle-phase-completion.sh` に v3-flat 構造（`intent.md` / `work-items/` + リポジトリ直下 `state.json`）の完了判定を追加し、`cycle/*` 命名の v3 サイクル main 宛て PR が CI を通過できるようにする。構造判別は opt-in シグナル方式（`work-items/` の存在 / 曖昧構造は exit 2 fail-closed）、state.json / frontmatter の読取は v3 安全境界スクリプトへ委譲。v2 サイクル向け既存判定は非影響で維持
+
+### Notes
+
+- #745（release hard gate の required CI 0 件時フォールバック方針）は Phase 7 前の後続サイクルへ defer
+
+---
+
 ## [3.0.0-beta.1] - 2026-07-03
 
 AI-DLC v3 フルリニューアルを **ベータ（preview）として初めて `main` に反映**する。v3（`skills/aidlc-v3` = `/aidlc-v3`）を v2（`skills/aidlc` = `/aidlc`）と**共存**させ、v2 側は無変更・既定のまま。実ユーザーからのフィードバックを得るソフトローンチであり、フル本流化（`/aidlc` の v3 置換）は後続（Phase 7）で行う。


### PR DESCRIPTION
# release: v3.0.0-beta.2 post-merge bookkeeping

PR #748（cycle/v3.0.0-beta.2）merge 後の release フロー Step 4 bookkeeping。main が保護ブランチのため follow-up PR で反映する（release フローの規定経路）。

## 変更内容

- `journal.md`: release completed 記録を追記（PR #748 merged / merge commit c0b3f09a）
- `release.md`: Merge 記録セクションの merged 行を更新
- `CHANGELOG.md`: 3.0.0-beta.2 エントリを追加（changelog opt-in / rules.release.changelog=true）
- `.claude-plugin/marketplace.json`: metadata.version を 3.0.0-beta.2 へ更新（check-marketplace-version.sh ガード充足 / auto-tag.yml が main push 時に tag 作成）

## 検証

- `bash bin/check-marketplace-version.sh --base origin/main --current HEAD` → ok（base 3.0.0-beta.1 → current 3.0.0-beta.2）
- `npx markdownlint-cli2 CHANGELOG.md` → 0 error
