### PR TITLE
release: v3.0.0-beta.3 post-merge bookkeeping

### DIFF
--- a/.aidlc/cycles/v3.0.0-beta.3/journal.md
+++ b/.aidlc/cycles/v3.0.0-beta.3/journal.md
@@ -27,3 +27,11 @@
 - develop completed: 003-migrate-v2-to-v3-core
 - matrix_case: risky_standard（design: full + Rollback Note / review: code_security）。design 承認: manual 承認（semi_auto だが design 承認ポイントは review_not_executed フォールバックでユーザー承認）/ code+security review: codex 3R（R1 指摘 3 件〔security: path-traversal 中 2・出力インジェクション低 1〕→ path-guard 統合等で resolved / R2 指摘 1 件低〔target ディレクトリ誤動作〕→ resolved / R3 clean）auto_approved
 - 確定内容: v2→v3 migration を既存 aidlc-migrate 拡張で実装（新規スキルにしない / SKILL.md に世代ルーティング新設）。new-cycle-only（必須）+ archive-only を steps/v3-migrate.md（人間ゲート 2 箇所 / 片方向警告 / commit しない）+ scripts/migrate-v3-{preflight,config,archive-index}.sh で提供。best-effort は選択時に書き込みゼロで安全中断。archive index 仕様を確定（.aidlc/v2-archive.md / work-items/ 非保有を archive 判定 / 冪等再生成）。state.json 初期化は state-init.sh 再利用（aidlc-v3 → aidlc の 2 候補解決）とし、define.md 4-3 に state.json 初期化済み resume 経路を追記して衝突解消。検証: tests/migration/ 78 pass（新規 29 / 世代差 fixtures 3 種）/ shellcheck・parse-guard・bash-substitution・skill-references・markdownlint green / 実 v2 config での new-cycle-only e2e 実行確認
+
+## 2026-07-11
+
+- release completed: v3.0.0-beta.3 (PR #750 merged)
+- 実行経路: `/aidlc-v3 o`（単文字 `o` は旧名 operations = release と解釈）。Step 1 リリース準備（全 work item done / bats 913 pass / clean worktree）→ Step 2 PR 整備（PR #750 draft 作成 / release.pr_number 記録 / release-level review 3 perspective / release.md 生成）→ Step 3 merge 承認 + 実行（semi_auto 自動承認: merge_blocker_any=false / hard gate: required 5 件全 pass + CLEAN + head 一致 / --match-head-commit merge）→ Step 4 post-merge
+- release-level review（codex / required）: premerge 2R（R1 指摘 1 件中〔release 成果物未コミット〕→ resolved）/ integration 3R（R1 指摘 1 件中〔archive-only 定義乖離疑い → 検証の結果 migration.md §2 の表現誤読誘発と判断し明確化〕→ R2 指摘 1 件低〔§3.1 適用対象欠落〕→ R3 clean）/ deploy 3R（R1 指摘 2 件中〔preflight state-init 未検証 → 解決検証 + テスト 2 件追加 / プレビュー API 不一致 → 事実誤認と確認〕→ R2 指摘 1 件低〔override 解決契約不一致 → Step 5 に明記〕→ R3 clean）。指摘対応コミット: c421ade9 / 9d545a3f
+- gh pr edit はトークンスコープ（read:org 要求）で失敗するため gh api PATCH フォールバックで PR 本文更新
+- tag: skip（version_tag=false）/ changelog: 追記（changelog=true）

--- a/.aidlc/cycles/v3.0.0-beta.3/release.md
+++ b/.aidlc/cycles/v3.0.0-beta.3/release.md
@@ -77,4 +77,4 @@ merge_blocker_any: false
 <!-- merge 記録は release Step 3/4 で追記する（テンプレート生成時点では未記録）。 -->
 
 - merge_approved: true（2026-07-11 / semi_auto 自動承認: merge_blocker_any=false / release.ready=true 記録済み）
-- merged: 未記録（Step 4 で記録）
+- merged: true（2026-07-11T05:32:41Z / merge commit a99df4cbc63b8b79bbe33714243d67e7b0dcae13 / merge method: merge / --match-head-commit a75cd5ae）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ AI-DLC Starter Kit の変更履歴です。
 
 ---
 
+## [3.0.0-beta.3] - 2026-07-11
+
+Phase 7 本流化（7-e）の残り前提である release hard gate の required CI 0 件フォールバック（#745 / 7-d 残り）と v2 → v3 migration 実装（7-c）を完成させ、v3 を本流化可能な状態にする（Epic #736）。本サイクルも v3 スキル（`/aidlc-v3`）の define → develop → release フローで駆動（セルフドッグフーディング継続）。
+
+### Added
+
+- **v3 config.toml 終端キー集合の確定（SoT ギャップ解消）**: v3 config.toml の 8 キー schema（キー名 / 型 / 既定値 / 用途）を `docs/v3/data-model.md` §11 に新設し唯一の正本とする。維持 7 キー identity + 新規 1 キー（`rules.release.required_ci_zero_fallback` / 既定 false）+ drop 27 キー（警告のみ）。`migration.md` §8 の SoT ギャップ注記を解消し §3.1 キーマッピング表を新設
+- **release hard gate の required CI 0 件フォールバック（#745）**: v3 release フロー Step 3-4 hard gate に opt-in フォールバックを明文化。適用条件 = config フラグ true + PR identity 不変 + required 0 件の正常取得 + CLEAN/rollup 健全。発動 = ローカル検証（最低 1 件 pass 必須）+ ユーザー明示承認（semi_auto でも自動承認しない）+ release.md 記録。既定 false = 現行 fail-closed 不変
+- **v2 → v3 migration 実装（new-cycle-only + archive-only / Epic #736 7-c）**: `aidlc-migrate` を世代ルーティング化し v2→v3 フローを追加（`steps/v3-migrate.md` + `scripts/migrate-v3-{preflight,config,archive-index}.sh`）。人間確認ゲート 2 箇所 / 片方向移行警告 / 未サポートキーは警告のみ / best-effort は書き込みゼロで安全中断。preflight は state-init.sh / state-validate.sh の解決可能性を適用前検証（部分適用状態の防止）。テスト: v2 config 世代差 fixtures 3 種を含む tests/migration/ 80 pass
+
+### Notes
+
+- best-effort モードの実データ変換（units → work-items / progress → state.json / history → journal 等）は後続サイクルへ defer（Epic #736 に注記）
+- 7-e フル本流化（`skills/aidlc-v3` → `skills/aidlc` 置換 / README 刷新 / GA 化）は本サイクルに含まない
+
+---
+
 ## [3.0.0-beta.2] - 2026-07-04
 
 v3 ベータの既知バグと CI 非互換を解消し、v3 サイクルが `cycle/*` 命名の main 宛て PR で自走できる状態にする（#744 / #747）。本サイクル自体を v3 スキル（`/aidlc-v3`）の define → develop → release フローで駆動（セルフドッグフーディング継続）。v2（`/aidlc`）には非影響。


### PR DESCRIPTION
# release: v3.0.0-beta.3 post-merge bookkeeping

PR #750（[Release] v3.0.0-beta.3）merge 後の bookkeeping を main に反映する（v3 release フロー Step 4 / 保護ブランチのため follow-up PR 方式 / #749 と同運用）。

## 変更内容

- `.aidlc/cycles/v3.0.0-beta.3/journal.md`: release 完了記録（2026-07-11 / PR #750 merged / review 経過・hard gate 通過記録）を追記
- `.aidlc/cycles/v3.0.0-beta.3/release.md`: Merge 記録の merged 行を更新（merge commit a99df4cb）
- `CHANGELOG.md`: [3.0.0-beta.3] エントリを追加（changelog=true opt-in / version_tag=false のため tag は skip）

https://claude.ai/code/session_01SdMmRg9BCHtMRS3FktpWhC
