### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #752)

### DIFF
--- a/skills/reviewing-construction-code/SKILL.md
+++ b/skills/reviewing-construction-code/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reviewing-construction-code
 description: Reviews code for quality and security issues. Combines code quality review with security vulnerability detection. Use when reviewing code after generation in Construction Phase.
-argument-hint: [レビュー対象ファイルまたはディレクトリ]
+argument-hint: "[レビュー対象ファイルまたはディレクトリ]"
 compatibility: Requires codex CLI, claude CLI, or gemini CLI. Runs in read-only/sandbox mode.
 allowed-tools: Bash(codex:*) Bash(claude:*) Bash(gemini:*)
 ---

--- a/skills/reviewing-construction-design/SKILL.md
+++ b/skills/reviewing-construction-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reviewing-construction-design
 description: Reviews design artifacts for quality, pattern application, and API design. Use when performing design reviews in Construction Phase.
-argument-hint: [レビュー対象ファイルまたはディレクトリ]
+argument-hint: "[レビュー対象ファイルまたはディレクトリ]"
 compatibility: Requires codex CLI, claude CLI, or gemini CLI. Runs in read-only/sandbox mode.
 allowed-tools: Bash(codex:*) Bash(claude:*) Bash(gemini:*)
 ---

--- a/skills/reviewing-construction-integration/SKILL.md
+++ b/skills/reviewing-construction-integration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reviewing-construction-integration
 description: Reviews integration completeness including design-implementation consistency, review/test coverage, and completion criteria. Use when performing integration review in Construction Phase.
-argument-hint: [レビュー対象ファイルまたはディレクトリ]
+argument-hint: "[レビュー対象ファイルまたはディレクトリ]"
 compatibility: Requires codex CLI, claude CLI, or gemini CLI. Runs in read-only/sandbox mode.
 allowed-tools: Bash(codex:*) Bash(claude:*) Bash(gemini:*)
 ---

--- a/skills/reviewing-construction-plan/SKILL.md
+++ b/skills/reviewing-construction-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reviewing-construction-plan
 description: Reviews construction plans for architecture consistency and implementation feasibility. Use when reviewing implementation plans before approval.
-argument-hint: [レビュー対象ファイルまたはディレクトリ]
+argument-hint: "[レビュー対象ファイルまたはディレクトリ]"
 compatibility: Requires codex CLI, claude CLI, or gemini CLI. Runs in read-only/sandbox mode.
 allowed-tools: Bash(codex:*) Bash(claude:*) Bash(gemini:*)
 ---

--- a/skills/reviewing-operations-deploy/SKILL.md
+++ b/skills/reviewing-operations-deploy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reviewing-operations-deploy
 description: Reviews deployment plans for completeness, rollback procedures, and monitoring setup. Use when reviewing deployment plans before approval in Operations Phase.
-argument-hint: [レビュー対象ファイルまたはディレクトリ]
+argument-hint: "[レビュー対象ファイルまたはディレクトリ]"
 compatibility: Requires codex CLI, claude CLI, or gemini CLI. Runs in read-only/sandbox mode.
 allowed-tools: Bash(codex:*) Bash(claude:*) Bash(gemini:*)
 ---

--- a/skills/reviewing-operations-premerge/SKILL.md
+++ b/skills/reviewing-operations-premerge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reviewing-operations-premerge
 description: Reviews pull requests for overall quality before merging. Combines code quality and security checks at PR level. Use when performing pre-merge review in Operations Phase.
-argument-hint: [レビュー対象ファイルまたはディレクトリ]
+argument-hint: "[レビュー対象ファイルまたはディレクトリ]"
 compatibility: Requires codex CLI, claude CLI, or gemini CLI. Runs in read-only/sandbox mode.
 allowed-tools: Bash(codex:*) Bash(claude:*) Bash(gemini:*)
 ---


### PR DESCRIPTION
Closes #752.

## Summary

Purely mechanical single-character transform to 14 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (14)

- `skills/reviewing-inception-units/SKILL.md`
- `skills/reviewing-inception-intent/SKILL.md`
- `skills/reviewing-operations-deploy/SKILL.md`
- `skills/reviewing-construction-plan/SKILL.md`
- `skills/reviewing-inception-stories/SKILL.md`
- `skills/reviewing-operations-premerge/SKILL.md`
- `skills/reviewing-construction-integration/SKILL.md`
- `.aidlc/cycles/v1.21.0/jj-backup/SKILL.md`
- `skills/reviewing-construction-design/SKILL.md`
- `.aidlc/cycles/v1.10.1/story-artifacts/units/005-add-jj-skill.md`
- `skills/reviewing-construction-code/SKILL.md`
- `.aidlc/cycles/v1.15.1/requirements/existing_analysis.md`
- `.aidlc/cycles/v1.10.1/design-artifacts/logical-designs/add-jj-skill_logical_design.md`
- `.aidlc/cycles/v1.14.0/design-artifacts/logical-designs/reviewing-architecture_logical_design.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
